### PR TITLE
issue/194/fix: Fix ElementwiseInfo Meta Allocation

### DIFF
--- a/src/infiniop/elementwise/cpu/elementwise_cpu.h
+++ b/src/infiniop/elementwise/cpu/elementwise_cpu.h
@@ -102,7 +102,7 @@ struct DeviceImpl::Opaque {};
 
 template <typename... Args>
 utils::Result<DeviceImpl> DeviceImpl::create(Args &&...args) {
-    return utils::Result<DeviceImpl>(nullptr);
+    return INFINI_STATUS_NOT_IMPLEMENTED;
 }
 
 // Perform elementwise operation for different input types

--- a/src/infiniop/elementwise/elementwise.h
+++ b/src/infiniop/elementwise/elementwise.h
@@ -84,8 +84,9 @@ private:
           _output_contiguous(output_contiguous) {}
 
 public:
+    // Get the Memory size of the meta data in bytes
     inline size_t getMetaMemSize() const {
-        return _meta.size();
+        return _meta.size() * sizeof(size_t);
     }
     inline const int8_t *getMetaStart() const {
         return reinterpret_cast<const int8_t *>(_meta.data());
@@ -167,7 +168,7 @@ public:
                              + input_size * ndim * sizeof(shape_unit)
                              + input_size * ndim * sizeof(stride_unit)
                              + 2 * input_size * sizeof(bool);
-        std::vector<size_t> meta(meta_mem_size);
+        std::vector<size_t> meta(CEIL_DIV(meta_mem_size, sizeof(size_t)));
         int8_t *meta_ptr = reinterpret_cast<int8_t *>(meta.data());
 
         const auto output_shape = output_desc->shape();

--- a/src/infiniop/ops/swiglu/cuda/swiglu_cuda_internal.cuh
+++ b/src/infiniop/ops/swiglu/cuda/swiglu_cuda_internal.cuh
@@ -14,7 +14,7 @@ private:
         } else if constexpr (std::is_same_v<T, half>) {
             return hrcp(__hadd(half(1.f), __float2half(__expf(__half2float(__hneg(x))))));
         } else if constexpr (std::is_same_v<T, float>) {
-            return __frcp_rd(__fadd_rd(1, __expf(-x)));
+            return __frcp_rn(__fadd_rn(1, __expf(-x)));
         } else {
             return 1 / (1 + std::exp(-x));
         }
@@ -29,7 +29,7 @@ public:
         } else if constexpr (std::is_same_v<T, half>) {
             return __hmul(__hmul(gate, sigmoid(gate)), up);
         } else if constexpr (std::is_same_v<T, float>) {
-            return __fmul_rd(__fmul_rd(gate, sigmoid(gate)), up);
+            return __fmul_rn(__fmul_rn(gate, sigmoid(gate)), up);
         } else {
             return gate * sigmoid(gate) * up;
         }


### PR DESCRIPTION
 - Change the memory allocation of meta in ElementwiseInfo to use the correct size (previously it over-allocates);
 - Change the DeviceImpl::create() in cpu to return INFINI_STATUS_NOT_IMPLEMENTED instead;
 - Change swiglu CUDA implementation from using rd mode to rn mod.