### PR TITLE
issue/226: 修改_f32_to_f16()方法内的判断语句条件

### DIFF
--- a/src/utils/custom_types.cc
+++ b/src/utils/custom_types.cc
@@ -43,7 +43,7 @@ fp16_t _f32_to_f16(float val) {
     int32_t exponent = ((f32 >> 23) & 0xFF) - 127; // Extract and de-bias the exponent
     uint32_t mantissa = f32 & 0x7FFFFF;            // Extract the mantissa (fraction part)
 
-    if (exponent >= 31) { // Special cases for Inf and NaN
+    if (exponent >= 16) { // Special cases for Inf and NaN
         // NaN
         if (exponent == 128 && mantissa != 0) {
             return fp16_t{static_cast<uint16_t>(sign | 0x7E00)};


### PR DESCRIPTION
Fixes #226 在FP32转为FP16时，对于处理Inf and NaN时的判断，因为exponent的值为FP32的存储指数值减去偏置后得到的实际指数值，那么判断条件应该修改为>=16（15为FP16实际指数值正常情况下的上限）