### PR TITLE
issue/207 add operator: sigmoid op on cpu and cuda

### DIFF
--- a/include/infiniop.h
+++ b/include/infiniop.h
@@ -19,6 +19,7 @@
 #include "infiniop/ops/relu.h"
 #include "infiniop/ops/rms_norm.h"
 #include "infiniop/ops/rope.h"
+#include "infiniop/ops/sigmoid.h"
 #include "infiniop/ops/swiglu.h"
 #include "infiniop/tensor_descriptor.h"
 

--- a/include/infiniop/ops/sigmoid.h
+++ b/include/infiniop/ops/sigmoid.h
@@ -1,0 +1,24 @@
+#ifndef __INFINIOP_SIGMOID_API_H__
+#define __INFINIOP_SIGMOID_API_H__
+
+#include "../operator_descriptor.h"
+
+typedef struct InfiniopDescriptor *infiniopSigmoidDescriptor_t;
+
+__C __export infiniStatus_t infiniopCreateSigmoidDescriptor(infiniopHandle_t handle,
+                                                            infiniopSigmoidDescriptor_t *desc_ptr,
+                                                            infiniopTensorDescriptor_t y,
+                                                            infiniopTensorDescriptor_t x);
+
+__C __export infiniStatus_t infiniopGetSigmoidWorkspaceSize(infiniopSigmoidDescriptor_t desc, size_t *size);
+
+__C __export infiniStatus_t infiniopSigmoid(infiniopSigmoidDescriptor_t desc,
+                                            void *workspace,
+                                            size_t workspace_size,
+                                            void *y,
+                                            const void *x,
+                                            void *stream);
+
+__C __export infiniStatus_t infiniopDestroySigmoidDescriptor(infiniopSigmoidDescriptor_t desc);
+
+#endif

--- a/scripts/python_test.py
+++ b/scripts/python_test.py
@@ -17,6 +17,7 @@ def run_tests(args):
         "random_sample.py",
         "rms_norm.py",
         "rope.py",
+        "sigmoid.py",
         "swiglu.py",
         "attention.py",
     ]:

--- a/src/infiniop-test/include/ops.hpp
+++ b/src/infiniop-test/include/ops.hpp
@@ -11,6 +11,7 @@ DECLARE_INFINIOP_TEST(rms_norm)
 DECLARE_INFINIOP_TEST(mul)
 DECLARE_INFINIOP_TEST(rope)
 DECLARE_INFINIOP_TEST(clip)
+DECLARE_INFINIOP_TEST(sigmoid)
 DECLARE_INFINIOP_TEST(swiglu)
 DECLARE_INFINIOP_TEST(add)
 
@@ -34,6 +35,7 @@ DECLARE_INFINIOP_TEST(add)
         REGISTER_INFINIOP_TEST(add)           \
         REGISTER_INFINIOP_TEST(mul)           \
         REGISTER_INFINIOP_TEST(clip)          \
+        REGISTER_INFINIOP_TEST(sigmoid)       \
         REGISTER_INFINIOP_TEST(swiglu)        \
         REGISTER_INFINIOP_TEST(rope)          \
         REGISTER_INFINIOP_TEST(rms_norm)      \

--- a/src/infiniop-test/src/ops/sigmoid.cpp
+++ b/src/infiniop-test/src/ops/sigmoid.cpp
@@ -1,0 +1,103 @@
+#include "ops.hpp"
+#include "utils.hpp"
+#include <infinirt.h>
+#include <iomanip>
+#include <iostream>
+
+namespace infiniop_test::sigmoid {
+struct Test::Attributes {
+    std::shared_ptr<Tensor> x;
+    std::shared_ptr<Tensor> y;
+    std::shared_ptr<Tensor> ans;
+};
+
+std::shared_ptr<Test> Test::build(
+    std::unordered_map<std::string, std::vector<uint8_t>> attributes,
+    std::unordered_map<std::string, std::shared_ptr<Tensor>> tensors,
+    double rtol, double atol) {
+    auto test = std::shared_ptr<Test>(new Test(rtol, atol));
+    test->_attributes = new Attributes();
+    if (tensors.find("x") == tensors.end()
+        || tensors.find("y") == tensors.end()
+        || tensors.find("ans") == tensors.end()) {
+        throw std::runtime_error("Invalid Test");
+    }
+
+    test->_attributes->x = tensors["x"];
+    test->_attributes->y = tensors["y"];
+    test->_attributes->ans = tensors["ans"];
+
+    return test;
+}
+
+std::shared_ptr<infiniop_test::Result> Test::run(
+    infiniopHandle_t handle, infiniDevice_t device, int device_id, size_t warm_ups, size_t iterations) {
+    infiniopSigmoidDescriptor_t op_desc;
+    auto x = _attributes->x->to(device, device_id);
+    auto y = _attributes->y->to(device, device_id);
+    CHECK_OR(infiniopCreateSigmoidDescriptor(handle, &op_desc,
+                                             y->desc(),
+                                             x->desc()),
+             return TEST_FAILED(OP_CREATION_FAILED, "Failed to create op descriptor."));
+    size_t workspace_size;
+    CHECK_OR(infiniopGetSigmoidWorkspaceSize(op_desc, &workspace_size),
+             return TEST_FAILED(OP_CREATION_FAILED, "Failed to get workspace size."));
+    void *workspace;
+    CHECK_OR(infinirtMalloc(&workspace, workspace_size),
+             return TEST_FAILED(OP_CREATION_FAILED, "Failed to allocate workspace."));
+    CHECK_OR(infiniopSigmoid(op_desc, workspace, workspace_size,
+                             y->data(),
+                             x->data(),
+                             nullptr),
+             return TEST_FAILED(OP_EXECUTION_FAILED, "Failed during execution."));
+
+    try {
+        allClose(y, _attributes->ans, _rtol, _atol);
+    } catch (const std::exception &e) {
+        return TEST_FAILED(RESULT_INCORRECT, e.what());
+    }
+
+    double elapsed_time = 0.;
+
+    elapsed_time = benchmark(
+        [=]() {
+            infiniopSigmoid(
+                op_desc, workspace, workspace_size,
+                y->data(),
+                x->data(),
+                nullptr);
+        },
+        warm_ups, iterations);
+
+    infiniopDestroySigmoidDescriptor(op_desc);
+    infinirtFree(workspace);
+    return TEST_PASSED(elapsed_time);
+}
+
+std::vector<std::string> Test::attribute_names() {
+    return {};
+}
+
+std::vector<std::string> Test::tensor_names() {
+    return {"x", "y", "ans"};
+}
+
+std::vector<std::string> Test::output_names() {
+    return {"y"};
+}
+
+std::string Test::toString() const {
+    std::ostringstream oss;
+    oss << op_name() << std::endl;
+    oss << "- x: " << _attributes->x->info() << std::endl;
+    oss << "- y: " << _attributes->y->info() << std::endl;
+    oss << std::scientific << std::setprecision(2);
+    oss << "- rtol=" << _rtol << ", atol=" << _atol << std::endl;
+    return oss.str();
+}
+
+Test::~Test() {
+    delete _attributes;
+}
+
+} // namespace infiniop_test::sigmoid

--- a/src/infiniop/ops/sigmoid/cpu/sigmoid_cpu.cc
+++ b/src/infiniop/ops/sigmoid/cpu/sigmoid_cpu.cc
@@ -1,0 +1,49 @@
+#include "sigmoid_cpu.h"
+
+namespace op::sigmoid::cpu {
+
+Descriptor::~Descriptor() = default;
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle_,
+    Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t out_desc,
+    std::vector<infiniopTensorDescriptor_t> input_desc_vec) {
+
+    auto handle = reinterpret_cast<device::cpu::Handle *>(handle_);
+    auto dtype = out_desc->dtype();
+
+    const auto &x_desc = input_desc_vec.at(0);
+    const auto &y_shape = out_desc->shape();
+    const auto &x_shape = x_desc->shape();
+
+    CHECK_DTYPE(dtype, INFINI_DTYPE_F16, INFINI_DTYPE_F32, INFINI_DTYPE_F64);
+    CHECK_SAME_SHAPE(y_shape, x_shape);
+
+    // create CPU elementwise descriptor
+    CREATE_ELEMENTWISE_CPU_DESCRIPTOR(handle, dtype, out_desc, input_desc_vec);
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(
+    void *workspace,
+    size_t workspace_size,
+    void *output,
+    std::vector<const void *> inputs,
+    void *stream) const {
+
+    switch (_dtype) {
+    case INFINI_DTYPE_F16:
+        return _device_info->calculate<SigmoidOp, fp16_t>(_info, output, inputs, stream);
+    case INFINI_DTYPE_F32:
+        return _device_info->calculate<SigmoidOp, float>(_info, output, inputs, stream);
+    case INFINI_DTYPE_F64:
+        return _device_info->calculate<SigmoidOp, double>(_info, output, inputs, stream);
+    default:
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+
+    return INFINI_STATUS_SUCCESS;
+}
+} // namespace op::sigmoid::cpu

--- a/src/infiniop/ops/sigmoid/cpu/sigmoid_cpu.h
+++ b/src/infiniop/ops/sigmoid/cpu/sigmoid_cpu.h
@@ -1,0 +1,19 @@
+#ifndef __SIGMOID_CPU_H__
+#define __SIGMOID_CPU_H__
+
+#include "../../../elementwise/cpu/elementwise_cpu.h"
+
+ELEMENTWISE_DESCRIPTOR(sigmoid, cpu)
+
+namespace op::sigmoid::cpu {
+typedef struct SigmoidOp {
+public:
+    static constexpr size_t num_inputs = 1;
+    template <typename T>
+    T operator()(const T &x) const {
+        return T(1) / (T(1) + std::exp(-x));
+    }
+} SigmoidOp;
+} // namespace op::sigmoid::cpu
+
+#endif // __SIGMOID_CPU_H__

--- a/src/infiniop/ops/sigmoid/cuda/sigmoid_cuda.cu
+++ b/src/infiniop/ops/sigmoid/cuda/sigmoid_cuda.cu
@@ -1,0 +1,55 @@
+#include "sigmoid_cuda.cuh"
+#include "sigmoid_cuda_internal.cuh"
+
+namespace op::sigmoid::cuda {
+
+Descriptor::~Descriptor() = default;
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle_,
+    Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t out_desc,
+    std::vector<infiniopTensorDescriptor_t> input_desc_vec) {
+
+    auto handle = reinterpret_cast<device::cuda::Handle *>(handle_);
+    auto dtype = out_desc->dtype();
+
+    const auto &x_desc = input_desc_vec.at(0);
+    const auto &y_shape = out_desc->shape();
+    const auto &x_shape = x_desc->shape();
+
+    CHECK_DTYPE(dtype, INFINI_DTYPE_F16, INFINI_DTYPE_F32, INFINI_DTYPE_F64);
+
+    CHECK_SAME_SHAPE(y_shape, x_shape);
+
+    // create CUDA elementwise descriptor
+    CREATE_ELEMENTWISE_CUDA_DESCRIPTOR(handle, dtype, out_desc, input_desc_vec)
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(
+    void *workspace,
+    size_t workspace_size,
+    void *output,
+    std::vector<const void *> inputs,
+    void *stream) const {
+
+    if (workspace_size < _workspace_size) {
+        return INFINI_STATUS_INSUFFICIENT_WORKSPACE;
+    }
+
+    switch (_dtype) {
+    case INFINI_DTYPE_F16:
+        return _device_info->calculate<256, SigmoidOp, half>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_F32:
+        return _device_info->calculate<256, SigmoidOp, float>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_F64:
+        return _device_info->calculate<256, SigmoidOp, double>(_info, workspace, output, inputs, stream);
+    default:
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+
+    return INFINI_STATUS_SUCCESS;
+}
+} // namespace op::sigmoid::cuda

--- a/src/infiniop/ops/sigmoid/cuda/sigmoid_cuda.cuh
+++ b/src/infiniop/ops/sigmoid/cuda/sigmoid_cuda.cuh
@@ -1,0 +1,8 @@
+#ifndef __SIGMOID_CUDA_API_H__
+#define __SIGMOID_CUDA_API_H__
+
+#include "../../../elementwise/cuda/elementwise_cuda_api.cuh"
+
+ELEMENTWISE_DESCRIPTOR(sigmoid, cuda)
+
+#endif // __SIGMOID_CUDA_API_H__

--- a/src/infiniop/ops/sigmoid/cuda/sigmoid_cuda_internal.cuh
+++ b/src/infiniop/ops/sigmoid/cuda/sigmoid_cuda_internal.cuh
@@ -1,0 +1,30 @@
+#ifndef __SIDMOID_CUDA_H__
+#define __SIDMOID_CUDA_H__
+
+#include "../../../elementwise/cuda/elementwise_cuda.cuh"
+#include <cuda_fp16.h>
+
+namespace op::sigmoid::cuda {
+typedef struct SigmoidOp {
+public:
+    static constexpr size_t num_inputs = 1;
+    template <typename T>
+    __device__ __forceinline__ T operator()(const T &x) const {
+        // sigmoid(x) = 1 / (1 + exp(-x))
+        if constexpr (std::is_same_v<T, half2>) {
+            half2 denominator = __hadd2(make_half2(1, 1), h2exp(__hneg2(x)));
+            return h2rcp(denominator);
+        } else if constexpr (std::is_same_v<T, half>) {
+            half denominator = __hadd(__float2half(1.0f), hexp(__hneg(x)));
+            return hrcp(denominator);
+        } else if constexpr (std::is_same_v<T, float>) {
+            float denominator = __fadd_rn(1.0f, __expf(-x));
+            return __frcp_rn(denominator);
+        } else { // double
+            return 1.0 / (1.0 + exp(-x));
+        }
+    }
+} SigmoidOp;
+} // namespace op::sigmoid::cuda
+
+#endif // __SIDMOID_CUDA_H__

--- a/src/infiniop/ops/sigmoid/operator.cc
+++ b/src/infiniop/ops/sigmoid/operator.cc
@@ -1,0 +1,115 @@
+#include "../../operator.h"
+#include "../../handle.h"
+#include "infiniop/ops/sigmoid.h"
+
+#ifdef ENABLE_CPU_API
+#include "cpu/sigmoid_cpu.h"
+#endif
+#ifdef ENABLE_CUDA_API
+#include "cuda/sigmoid_cuda.cuh"
+#endif
+
+__C infiniStatus_t infiniopCreateSigmoidDescriptor(
+    infiniopHandle_t handle,
+    infiniopSigmoidDescriptor_t *desc_ptr,
+    infiniopTensorDescriptor_t y_desc,
+    infiniopTensorDescriptor_t x_desc) {
+
+#define CREATE(CASE, NAMESPACE)                                                \
+    case CASE:                                                                 \
+        return op::sigmoid::NAMESPACE::Descriptor::create(                     \
+            handle,                                                            \
+            reinterpret_cast<op::sigmoid::NAMESPACE::Descriptor **>(desc_ptr), \
+            y_desc,                                                            \
+            {x_desc})
+
+    switch (handle->device) {
+
+#ifdef ENABLE_CPU_API
+        CREATE(INFINI_DEVICE_CPU, cpu);
+#endif
+#ifdef ENABLE_CUDA_API
+        CREATE(INFINI_DEVICE_NVIDIA, cuda);
+#endif
+
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+
+#undef CREATE
+}
+
+__C infiniStatus_t infiniopGetSigmoidWorkspaceSize(infiniopSigmoidDescriptor_t desc, size_t *size) {
+
+#define GET(CASE, NAMESPACE)                                                                   \
+    case CASE:                                                                                 \
+        *size = reinterpret_cast<op::sigmoid::NAMESPACE::Descriptor *>(desc)->workspaceSize(); \
+        return INFINI_STATUS_SUCCESS;
+
+    switch (desc->device_type) {
+#ifdef ENABLE_CPU_API
+        GET(INFINI_DEVICE_CPU, cpu)
+#endif
+#ifdef ENABLE_CUDA_API
+        GET(INFINI_DEVICE_NVIDIA, cuda)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef GET
+
+    return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+}
+
+__C infiniStatus_t infiniopSigmoid(
+    infiniopSigmoidDescriptor_t desc,
+    void *workspace,
+    size_t workspace_size,
+    void *y,
+    const void *x,
+    void *stream) {
+
+#define CALCULATE(CASE, NAMESPACE)                                                \
+    case CASE:                                                                    \
+        return reinterpret_cast<const op::sigmoid::NAMESPACE::Descriptor *>(desc) \
+            ->calculate(workspace, workspace_size, y, {x}, stream)
+
+    switch (desc->device_type) {
+
+#ifdef ENABLE_CPU_API
+        CALCULATE(INFINI_DEVICE_CPU, cpu);
+#endif
+#ifdef ENABLE_CUDA_API
+        CALCULATE(INFINI_DEVICE_NVIDIA, cuda);
+#endif
+
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+
+#undef CALCULATE
+}
+
+__C infiniStatus_t
+infiniopDestroySigmoidDescriptor(infiniopSigmoidDescriptor_t desc) {
+
+#define DELETE(CASE, NAMESPACE)                                                    \
+    case CASE:                                                                     \
+        delete reinterpret_cast<const op::sigmoid::NAMESPACE::Descriptor *>(desc); \
+        return INFINI_STATUS_SUCCESS;
+
+    switch (desc->device_type) {
+
+#ifdef ENABLE_CPU_API
+        DELETE(INFINI_DEVICE_CPU, cpu);
+#endif
+#ifdef ENABLE_CUDA_API
+        DELETE(INFINI_DEVICE_NVIDIA, cuda);
+#endif
+
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+
+#undef DELETE
+}

--- a/test/infiniop-test/test_generate/testcases/sigmoid.py
+++ b/test/infiniop-test/test_generate/testcases/sigmoid.py
@@ -1,0 +1,136 @@
+import numpy as np
+from numpy.lib.stride_tricks import as_strided
+import gguf
+from typing import List
+
+from .. import InfiniopTestWriter, InfiniopTestCase, np_dtype_to_ggml, gguf_strides, contiguous_gguf_strides, process_zero_stride_tensor
+
+
+def sigmoid(
+        x: np.ndarray,
+):
+    return 1 / (1 + np.exp(-x))
+
+
+def random_tensor(shape, dtype):
+    rate = 1e-3
+    var = 0.5 * rate
+    return rate * np.random.rand(*shape).astype(dtype) - var
+
+
+def process_tensors(a, b, stride_a=None, stride_b=None):
+    def normalize_stride(tensor, stride):
+        if stride:
+            slices = tuple(slice(0, 1) if s == 0 else slice(None) for s in stride)
+            return tensor[slices]
+        else:
+            return tensor
+
+    a_unique = normalize_stride(a, stride_a)
+    b_unique = normalize_stride(b, stride_b)
+    return a_unique, b_unique
+
+
+def process_tensor(a, stride_a=None):
+    def normalize_stride(tensor, stride):
+        if stride:
+            slices = tuple(slice(0, 1) if s == 0 else slice(None) for s in stride)
+            return tensor[slices]
+        else:
+            return tensor
+
+    a_unique = normalize_stride(a, stride_a)
+    return a_unique
+
+
+class SigmoidTestCase(InfiniopTestCase):
+    def __init__(
+            self,
+            x: np.ndarray,
+            shape_x: List[int] | None,
+            stride_x: List[int] | None,
+            y: np.ndarray,
+            shape_y: List[int] | None,
+            stride_y: List[int] | None,
+    ):
+        super().__init__("sigmoid")
+        self.x = x
+        self.shape_x = shape_x
+        self.stride_x = stride_x
+
+        self.y = y
+        self.shape_y = shape_y
+        self.stride_y = stride_y
+
+    def write_test(self, test_writer: "InfiniopTestWriter"):
+        super().write_test(test_writer)
+
+        if self.shape_x is not None:
+            test_writer.add_array(test_writer.gguf_key("x.shape"), self.shape_x)
+        if self.shape_y is not None:
+            test_writer.add_array(test_writer.gguf_key("y.shape"), self.shape_y)
+
+        if self.stride_x is not None:
+            test_writer.add_array(test_writer.gguf_key("x.strides"), gguf_strides(*self.stride_x))
+
+        test_writer.add_array(
+            test_writer.gguf_key("y.strides"),
+            gguf_strides(*self.stride_y if self.stride_y is not None else contiguous_gguf_strides(self.shape_y))
+        )
+
+        test_writer.add_tensor(
+            test_writer.gguf_key("x"), self.x, raw_dtype=np_dtype_to_ggml(self.x.dtype)
+        )
+        test_writer.add_tensor(
+            test_writer.gguf_key("y"), self.y, raw_dtype=np_dtype_to_ggml(self.y.dtype)
+        )
+
+        input_x = self.x.astype(np.float64)
+        if (self.stride_x is not None) and (0 in self.stride_x):
+            typesize = np.dtype(input_x.dtype).itemsize
+            new_strides_bytes = tuple(x * typesize for x in self.stride_x)
+            input_x = as_strided(x=input_x, shape=self.shape_x, strides=new_strides_bytes)
+
+        ans = sigmoid(input_x)
+
+        test_writer.add_tensor(
+            test_writer.gguf_key("ans"), ans, raw_dtype=gguf.GGMLQuantizationType.F64
+        )
+
+
+if __name__ == '__main__':
+    test_writer = InfiniopTestWriter("sigmoid.gguf")
+
+    test_cases = []
+    _TEST_CASES_ = [
+        # shape, x_stride, y_stride
+        ((13, 4), None, None),
+        ((13, 4), (10, 1), (10, 1)),
+        ((13, 4), (0, 1), None),
+        ((13, 4, 4), None, None),
+        ((13, 4, 4), (20, 4, 1), (20, 4, 1)),
+        ((13, 4, 4), (4, 0, 1), None),
+        ((16, 5632), None, None),
+        ((16, 5632), (13312, 1), (13312, 1)),
+        ((4, 4, 5632), None, None),
+        ((4, 4, 5632), (45056, 5632, 1), (45056, 5632, 1)),
+    ]
+    _TENSOR_DTYPES_ = [np.float16, np.float32]
+
+    for dtype in _TENSOR_DTYPES_:
+        for shape, stride_x, stride_y in _TEST_CASES_:
+            x = np.random.rand(*shape).astype(dtype)
+            y = np.empty(tuple(0 for _ in shape), dtype=dtype)
+
+            x = process_zero_stride_tensor(x, stride_x)
+            test_case = SigmoidTestCase(x=x,
+                                        shape_x=shape,
+                                        stride_x=stride_x,
+                                        y=y,
+                                        shape_y=shape,
+                                        stride_y=stride_y)
+
+            test_cases.append(test_case)
+
+    test_writer.add_tests(test_cases)
+    test_writer.save()

--- a/test/infiniop/sigmoid.py
+++ b/test/infiniop/sigmoid.py
@@ -1,0 +1,239 @@
+import os
+
+import torch
+import ctypes
+from ctypes import POINTER, Structure, c_int32, c_void_p, c_uint64
+from libinfiniop import (infiniopHandle_t,
+                         infiniopTensorDescriptor_t,
+                         open_lib,
+                         to_tensor,
+                         get_test_devices,
+                         check_error,
+                         rearrange_if_needed,
+                         test_operator,
+                         get_args,
+                         debug,
+                         get_tolerance,
+                         profile_operation,
+                         create_workspace,
+                         )
+from enum import Enum, auto
+
+# ==============================================================================
+#  Configuration (Internal Use Only)
+# ==============================================================================
+# These are not meant to be imported from other modules
+_TEST_CASES_ = [
+    # shape, x_stride, y_stride  
+    ((13, 4), None, None),
+    ((13, 4), (10, 1), (10, 1)),
+    ((13, 4), (0, 1), None,),
+    ((13, 4, 4), None, None),
+    ((13, 4, 4), (20, 4, 1), (20, 4, 1)),
+    ((13, 4, 4), (4, 0, 1), None),
+    ((16, 5632), None, None),
+    ((16, 5632), (13312, 1), (13312, 1)),
+    ((4, 4, 5632), None, None),
+    ((4, 4, 5632), (45056, 5632, 1), (45056, 5632, 1)),
+    ((4, 4, 56320), None, None),
+]
+
+
+class Inplace(Enum):
+    OUT_OF_PLACE = auto() 
+    INPLACE_X = auto() 
+
+
+# Inplace options applied for each test case in _TEST_CASES_
+_INPLACE = [
+    Inplace.OUT_OF_PLACE,
+    Inplace.INPLACE_X,
+]
+
+# Form the test cases by appending each element of _INPLACE to each tuple in _TEST_CASES_
+_TEST_CASES = [
+    test_case + (inplace_item,)
+    for test_case in _TEST_CASES_
+    for inplace_item in _INPLACE
+]
+
+# Data types used for testing
+_TENSOR_DTYPES = [torch.float16, torch.float32, torch.float64]
+
+# Tolerance map for different data types
+_TOLERANCE_MAP = {
+    torch.float16: {"atol": 1e-3, "rtol": 1e-3},
+    torch.float32: {"atol": 1e-7, "rtol": 1e-7},
+    torch.float64: {"atol": 1e-7, "rtol": 1e-7},
+}
+
+DEBUG = False
+PROFILE = False
+NUM_PRERUN = 10
+NUM_ITERATIONS = 1000
+
+
+class SigmoidDescriptor(Structure):
+    _fields_ = [("device", c_int32)]
+
+
+infiniopSigmoidDescriptor_t = POINTER(SigmoidDescriptor)
+
+
+def sigmoid_torch(x):
+    return torch.sigmoid(x)
+
+
+def process_tensors(y, y_strides, x, x_stride, inplace):
+    """
+    rearrange the tensors if needed and apply the inplace config.
+    if inplace is true and the output (i.e., c) is placed to the broadcasted input,
+    the inplace config is ignored and out-of-place is used
+    """
+    original_y_strides = y_strides if y_strides else y.stride()
+
+
+    def _rearrange(tensor, strides):
+        if strides and 0 in strides:
+            tensor.set_(tensor.untyped_storage(), 0, tensor.shape, strides)
+            return tensor
+        else:
+            return rearrange_if_needed(tensor, strides)
+
+    x, y = [
+        _rearrange(tensor, stride)
+        for tensor, stride in zip([x, y], [x_stride, y_strides])
+    ]
+    y = (
+        y
+        if inplace == Inplace.OUT_OF_PLACE
+        else (x)
+    )
+    # if inplace is true and c has broadcasted config, reset it to the original unbroadcasted strides
+    if 0 in y.stride():
+        y.set_(y.untyped_storage(), 0, y.shape, original_y_strides)
+
+    return x, y
+
+
+def test(lib,
+         handle,
+         torch_device,
+         shape,
+         x_stride=None,
+         y_stride=None,
+         inplace=Inplace.OUT_OF_PLACE,
+         dtype=torch.float16,
+         sync=None,
+         ):
+    print(f"Testing Sigmoid on {torch_device} with shape:{shape} x_stride:{x_stride} c_stride:{y_stride} "
+          f"dtype:{dtype} inplace:{inplace}")
+
+    x = torch.rand(shape, dtype=dtype).to(torch_device) 
+    y = torch.rand(shape, dtype=dtype).to(torch_device)
+
+    x, y = process_tensors(y, y_stride, x, x_stride, inplace)
+
+    ans = sigmoid_torch(x)
+
+    x_tensor, = [to_tensor(tensor, lib) for tensor in [x, ]]
+    y_tensor = (
+        to_tensor(y, lib)
+        if inplace == Inplace.OUT_OF_PLACE
+        else x_tensor
+    )
+    if sync is not None:
+        sync()
+    
+    descriptor = infiniopSigmoidDescriptor_t()
+    check_error(
+        lib.infiniopCreateSigmoidDescriptor(
+            handle,
+            ctypes.byref(descriptor),
+            y_tensor.descriptor,
+            x_tensor.descriptor,
+        )
+    )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    for tensor in [x_tensor, y_tensor]:
+        tensor.destroyDesc(lib)
+
+    workspace_size = c_uint64(0)
+    check_error(
+        lib.infiniopGetSigmoidWorkspaceSize(descriptor, ctypes.byref(workspace_size))
+    )
+    workspace = create_workspace(workspace_size.value, y.device)
+
+    def lib_sigmoid():
+        check_error(
+            lib.infiniopSigmoid(
+                descriptor,
+                workspace.data_ptr() if workspace is not None else None,
+                workspace_size.value,
+                y_tensor.data,
+                x_tensor.data,
+                None,
+            )
+        )
+
+    lib_sigmoid()
+
+    atol, rtol = get_tolerance(_TOLERANCE_MAP, dtype)
+    if DEBUG:
+        debug(y, ans, atol=atol, rtol=rtol)
+
+    assert torch.allclose(y, ans, atol=atol, rtol=rtol)
+
+    # Profiling workflow
+    if PROFILE:
+        # fmt: off
+        profile_operation("PyTorch", lambda: sigmoid_torch(x), torch_device, NUM_PRERUN, NUM_ITERATIONS)
+        profile_operation("    lib", lambda: lib_sigmoid(), torch_device, NUM_PRERUN, NUM_ITERATIONS)
+        # fmt: on
+    check_error(lib.infiniopDestroySigmoidDescriptor(descriptor))
+
+
+if __name__ == "__main__":
+    args = get_args()
+    lib = open_lib()
+
+    lib.infiniopCreateSigmoidDescriptor.restype = c_int32
+    lib.infiniopCreateSigmoidDescriptor.argtypes = [
+        infiniopHandle_t,
+        POINTER(infiniopSigmoidDescriptor_t),
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+    ]
+
+    lib.infiniopGetSigmoidWorkspaceSize.restype = c_int32
+    lib.infiniopGetSigmoidWorkspaceSize.argtypes = [
+        infiniopSigmoidDescriptor_t,
+        POINTER(c_uint64),
+    ]
+
+    lib.infiniopSigmoid.restype = c_int32
+    lib.infiniopSigmoid.argtypes = [
+        infiniopSigmoidDescriptor_t,
+        c_void_p,
+        c_uint64,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+    ]
+
+    lib.infiniopDestroySigmoidDescriptor.restype = c_int32
+    lib.infiniopDestroySigmoidDescriptor.argtypes = [
+        infiniopSigmoidDescriptor_t,
+    ]
+ 
+    # Configure testing options
+    DEBUG = args.debug
+    PROFILE = args.profile
+    NUM_PRERUN = args.num_prerun
+    NUM_ITERATIONS = args.num_iterations
+
+    for device in get_test_devices(args):
+        test_operator(lib, device, test, _TEST_CASES, _TENSOR_DTYPES)
+
+    print("\033[92mTest passed!\033[0m")


### PR DESCRIPTION
issue/207 添加了 Sigmoid算子的头文件、cpu实现、cuda实现、python测试用例、gguf测试用例。
[https://github.com/InfiniTensor/InfiniCore/issues/207](https://github.com/InfiniTensor/InfiniCore/pull/url)
环境：
(1) cuda11.8 pytorch2.6 nvidia 4070ti
已修改（对比上一版本）：
（1）删除  stride_y = contiguous_gguf_strides(shape) 语句
（2） void const *x 改成 const  void  *x
（3） 删除不必要注释
![image](https://github.com/user-attachments/assets/a7d6caa3-7925-463c-b1ed-7d83d5291fb6)
![image](https://github.com/user-attachments/assets/d3d740b3-639e-4790-a034-055c174f173c)
![image](https://github.com/user-attachments/assets/a8c905cd-d04d-407e-ac20-afd08f4e838a)
![image](https://github.com/user-attachments/assets/f8ea9f72-ff70-4e12-bb29-f177c5548955)
