### PR TITLE
Issue/261: Optimize Torch Implementation of Several Operators

### DIFF
--- a/test/infiniop/add.py
+++ b/test/infiniop/add.py
@@ -79,8 +79,8 @@ class AddDescriptor(Structure):
 infiniopAddDescriptor_t = POINTER(AddDescriptor)
 
 
-def add(x, y):
-    return torch.add(x, y)
+def add(ans, x, y):
+    torch.add(x, y, out=ans)
 
 
 def process_tensors(c, c_strides, a, a_stride, b, b_stride, inplace):
@@ -134,9 +134,10 @@ def test(
     a = torch.rand(shape, dtype=dtype).to(torch_device)
     b = torch.rand(shape, dtype=dtype).to(torch_device)
     c = torch.rand(shape, dtype=dtype).to(torch_device)
+    ans = torch.zeros(shape, dtype=dtype).to(torch_device)
     a, b, c = process_tensors(c, c_stride, a, a_stride, b, b_stride, inplace)
 
-    ans = add(a, b)
+    add(ans, a, b)
 
     a_tensor, b_tensor = [to_tensor(tensor, lib) for tensor in [a, b]]
     c_tensor = (
@@ -191,7 +192,7 @@ def test(
     # Profiling workflow
     if PROFILE:
         # fmt: off
-        profile_operation("PyTorch", lambda: add(a, b), torch_device, NUM_PRERUN, NUM_ITERATIONS)
+        profile_operation("PyTorch", lambda: add(ans, a, b), torch_device, NUM_PRERUN, NUM_ITERATIONS)
         profile_operation("    lib", lambda: lib_add(), torch_device, NUM_PRERUN, NUM_ITERATIONS)
         # fmt: on
     check_error(lib.infiniopDestroyAddDescriptor(descriptor))

--- a/test/infiniop/causal_softmax.py
+++ b/test/infiniop/causal_softmax.py
@@ -73,9 +73,8 @@ infiniopCausalSoftmaxDescriptor_t = POINTER(CausalSoftmaxDescriptor)
 def causal_softmax(x):
     type = x.dtype
     mask = torch.tril(torch.ones_like(x), diagonal=-1).flip(dims=[-2, -1])
-    y = x.clone()
-    masked = torch.where(mask == 1, -torch.inf, y.to(torch.float32))
-    return torch.nn.functional.softmax(masked, dim=-1).to(type)
+    masked = torch.where(mask == 1, -torch.inf, x.to(torch.float32))
+    return torch.nn.functional.softmax(masked, dim=-1, dtype=type)
 
 
 def test(

--- a/test/infiniop/rearrange.py
+++ b/test/infiniop/rearrange.py
@@ -123,6 +123,13 @@ class RerrangeDescriptor(Structure):
 infiniopRearrangeDescriptor_t = POINTER(RerrangeDescriptor)
 
 
+def rearrange_torch(x, x_shape, y_stride):
+    y_ = x.clone()
+    y_.set_(y_.untyped_storage(), 0, x_shape, y_stride)
+    y_[:] = x.view_as(y_)
+    return y_
+
+
 def test(
     lib,
     handle,
@@ -139,6 +146,8 @@ def test(
 
     x = torch.rand(shape, dtype=dtype).to(torch_device)
     y = torch.zeros(shape, dtype=dtype).to(torch_device)
+
+    rearrange_torch(x, shape, y_stride)
 
     x, y = [
         rearrange_if_needed(tensor, stride)
@@ -177,7 +186,7 @@ def test(
     # Profiling workflow
     if PROFILE:
         # fmt: off
-        profile_operation("PyTorch", lambda: rearrange_tensor(y, y_stride), torch_device, NUM_PRERUN, NUM_ITERATIONS)
+        profile_operation("PyTorch", lambda: rearrange_torch(x, shape, y_stride), torch_device, NUM_PRERUN, NUM_ITERATIONS)
         profile_operation("    lib", lambda: lib_rearrange(), torch_device, NUM_PRERUN, NUM_ITERATIONS)
         # fmt: on
 

--- a/test/infiniop/rope.py
+++ b/test/infiniop/rope.py
@@ -201,7 +201,7 @@ def test(
     if PROFILE:
         profile_operation(
             "PyTorch",
-            lambda: rotary_embedding(x, pos, theta, torch_device),
+            lambda: rotary_embedding(x, sin_table, cos_table, torch_device),
             torch_device,
             NUM_PRERUN,
             NUM_ITERATIONS,


### PR DESCRIPTION
 - Optimize the implementation of several operators: `add`, `causal softmax`, `gemm`, `random sample`, `rearrange`, and `rms norm`
 - Fix some test issues under profile mode (e.g., `rope.py` under profile mode has incorrect argument list for the torch implementation, the original torch implementation of `rearrange` cannot pass a test case under profile mode)  
 - Remove duplicate test cases in `gemm.py`

screenshots:
add:
<img width="925" alt="image" src="https://github.com/user-attachments/assets/8605dcd7-d604-4163-86ee-408b4ae8f73f" />
causal softmax (left: original, right: torch optimized):
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/5bf84153-0f58-430f-9e7c-9780ed8b16bb" />
gemm (left: original, right: torch optimized) **Improvement: ~84%:**
<img width="1513" alt="image" src="https://github.com/user-attachments/assets/77366f64-95f1-4f58-bdf9-f7240d13461b" />
random sample(left: original, right: torch optimized) **Improvement: ~99%:**
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/7df41f87-bd30-44f1-b803-6726990bbea4" />
(p.s.: the original one is too slow to finish)
rearrange(left: original, right: torch optimized) **Improvement: ~93%:**
<img width="1325" alt="image" src="https://github.com/user-attachments/assets/0155da9b-9900-4056-84db-6852d65e7636" />
rms norm(left: original, right: torch optimized) **Improvement: ~39%:**
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/4ae5d2cc-7684-48a3-b5a6-221556080a01" />
rope:
<img width="941" alt="image" src="https://github.com/user-attachments/assets/7a45c163-8e7f-42e8-b823-6e1eb0d70aee" />
