### PR TITLE
issue/335- add the path of INFINI_ROOT and improve the one-click inst…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,23 @@ API 定义以及使用方式详见 [`InfiniCore文档`](https://github.com/Infin
 
 ### 一键安装
 
-在 `script/` 目录中提供了 `install.py` 安装脚本。使用方式如下：
+在 `script/` 目录中提供了 `install` 安装脚本。使用方式如下：
 
+linux 系统：在`terminal`中执行
 ```shell
 cd InfiniCore
-
+source scripts/install.sh [XMAKE_CONFIG_FLAGS]
+# 例如
+# source scripts/install.sh    配置 CPU（默认配置）
+# source scripts/install.sh --nv-gpu=true --cuda=$CUDA_HOME   配置 英伟达 加速卡
+```
+windows 系统：在`CMD`中执行
+```shell
+cd InfiniCore
 python scripts/install.py [XMAKE_CONFIG_FLAGS]
+# 例如
+# python scripts/install.py    配置 CPU（默认配置）
+# python scripts/install.py --nv-gpu=true --cuda=\""%CUDA_HOME%"\"   配置 英伟达 加速卡
 ```
 
 参数 `XMAKE_CONFIG_FLAGS` 是 xmake 构建配置，可配置下列可选项：

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+python scripts/install.py ${@:1}
+
+if [ -z "${INFINI_ROOT}" ]; then
+    sleep 1
+    . ~/.bashrc
+fi

--- a/xmake.lua
+++ b/xmake.lua
@@ -18,6 +18,38 @@ if is_plat("windows") then
     add_cxflags("/utf-8", {force = true})
 end
 
+-- 添加INFINI_ROOT环境变量
+on_config(function()
+    function Check_INFINI_ROOT()
+        if is_plat("windows") then
+            return
+        end
+
+        -- .bashrc文件中是否有INFINI_ROOT
+        local marker = "# INFINI_ROOT configuration (auto-added by xmake.lua).\n"
+        local bashrc_path = path.join(os.getenv("HOME"), ".bashrc")
+        if io.readfile(bashrc_path):find(marker, 1, true) then
+            return
+        end
+        
+        -- 向.bashrc文件中添加 INFINI_ROOT
+        local INFINI_ROOT = path.join(os.getenv("HOME"), ".infini")
+        print(string.format("INFINI_ROOT not set!!! New INFINI_ROOT: %s\n", INFINI_ROOT))
+        local file = io.open(bashrc_path, "a")
+        if file then
+            file:write("\n")
+            file:write(marker)
+            file:write(string.format("export INFINI_ROOT=%s\n",INFINI_ROOT))
+            file:write(string.format("export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$INFINI_ROOT/lib\n"))
+            file:flush()
+            file:close()
+        else
+            print(string.format("could not open file: %s\n",bashrc_path))
+        end
+    end
+    Check_INFINI_ROOT()
+end)
+
 -- CPU
 option("cpu")
     set_default(true)


### PR DESCRIPTION
**自动添加INFINI_ROOT环境变量和一键安装脚本。**

**修改1**：自动向.bashrc中添加 INFINI_ROOT 环境变量。
在xmake.lua中的on_config中添加了Check_INFINI_ROOT()函数，函数流程如下：
1  读.bashrc文件，判断是否有NFINI_ROOT
2  若没有，则向文件中写入INFINI_ROOT

**修改2**：在scripts中增加了 install.sh 脚本。
 install.sh 主要作用是 执行 source ~/.bashrc 命令。

**修改3**：在Readme.md中，完善了**一键安装** 的说明，并给出了示例。
linux 系统上运行  scripts/install.sh 脚本。
windows 系统上运行 scripts/install.py 脚本。

**测试过程**：编译和测试都通过
1 编译前，不存在 INFINI_ROOT 环境变量。
2 使用 install.sh 一键编译后， INFINI_ROOT 环境变量就出现在当前终端了。
3 最后在当前终端进行 算子测试，测试通过。
<img width="984" height="726" alt="Screenshot from 2025-07-18 17-47-46" src="https://github.com/user-attachments/assets/1788bcac-b157-40b3-a67c-8116232e2427" />
