### PR TITLE
issue/158/feat: 接入天数 ccl

### DIFF
--- a/src/infiniccl-test/infiniccl_test.cpp
+++ b/src/infiniccl-test/infiniccl_test.cpp
@@ -10,7 +10,7 @@
 #define TEST_INFINI(API__) CHECK_API_OR(API__, INFINI_STATUS_SUCCESS, return 1)
 #define TEST_INFINI_THREAD(API__) CHECK_API_OR(API__, INFINI_STATUS_SUCCESS, return nullptr)
 
-const size_t MAX_COUNT = 100ULL * 1024 * 1024;
+const size_t MAX_COUNT = 8ULL * 1024 * 1024;
 
 const size_t TEST_COUNTS[] = {
     128,

--- a/src/infiniccl/infiniccl.cc
+++ b/src/infiniccl/infiniccl.cc
@@ -12,12 +12,13 @@ __C infiniStatus_t infinicclCommInitAll(
 
 #define COMM_INIT_ALL(CASE_, NAMESPACE_) \
     case CASE_:                          \
-        return infiniccl::NAMESPACE_::commInitAll(comms, ndevice, device_ids);
+        return infiniccl::NAMESPACE_::commInitAll(comms, ndevice, device_ids)
 
     switch (device_type) {
-        COMM_INIT_ALL(INFINI_DEVICE_NVIDIA, cuda)
-        COMM_INIT_ALL(INFINI_DEVICE_ASCEND, ascend)
-        COMM_INIT_ALL(INFINI_DEVICE_METAX, metax)
+        COMM_INIT_ALL(INFINI_DEVICE_NVIDIA, cuda);
+        COMM_INIT_ALL(INFINI_DEVICE_ILUVATAR, cuda);
+        COMM_INIT_ALL(INFINI_DEVICE_ASCEND, ascend);
+        COMM_INIT_ALL(INFINI_DEVICE_METAX, metax);
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
     }
@@ -32,12 +33,13 @@ __C infiniStatus_t infinicclCommDestroy(infinicclComm_t comm) {
 
 #define COMM_DESTROY(CASE_, NAMESPACE_) \
     case CASE_:                         \
-        return infiniccl::NAMESPACE_::commDestroy(comm);
+        return infiniccl::NAMESPACE_::commDestroy(comm)
 
     switch (comm->device_type) {
-        COMM_DESTROY(INFINI_DEVICE_NVIDIA, cuda)
-        COMM_DESTROY(INFINI_DEVICE_ASCEND, ascend)
-        COMM_DESTROY(INFINI_DEVICE_METAX, metax)
+        COMM_DESTROY(INFINI_DEVICE_NVIDIA, cuda);
+        COMM_DESTROY(INFINI_DEVICE_ILUVATAR, cuda);
+        COMM_DESTROY(INFINI_DEVICE_ASCEND, ascend);
+        COMM_DESTROY(INFINI_DEVICE_METAX, metax);
 
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
@@ -60,12 +62,13 @@ __C infiniStatus_t infinicclAllReduce(
 
 #define ALL_REDUCE(CASE_, NAMESPACE_) \
     case CASE_:                       \
-        return infiniccl::NAMESPACE_::allReduce(sendbuf, recvbuf, count, dataype, op, comm, stream);
+        return infiniccl::NAMESPACE_::allReduce(sendbuf, recvbuf, count, dataype, op, comm, stream)
 
     switch (comm->device_type) {
-        ALL_REDUCE(INFINI_DEVICE_NVIDIA, cuda)
-        ALL_REDUCE(INFINI_DEVICE_ASCEND, ascend)
-        ALL_REDUCE(INFINI_DEVICE_METAX, metax)
+        ALL_REDUCE(INFINI_DEVICE_NVIDIA, cuda);
+        ALL_REDUCE(INFINI_DEVICE_ILUVATAR, cuda);
+        ALL_REDUCE(INFINI_DEVICE_ASCEND, ascend);
+        ALL_REDUCE(INFINI_DEVICE_METAX, metax);
 
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;


### PR DESCRIPTION
```plaintext
$ xmake run infiniccl-test --iluvatar
cudadevrt removed, syslinks = { rt, pthread, dl }
cudadevrt removed, syslinks = { rt, pthread, dl }
cudadevrt removed, syslinks = { rt, pthread, dl }
Found 16 devices. Running tests...
Testing AllReduce with 128 elements of F32
Rank 0: 0.186252 ms.
Rank 1: 0.186238 ms.
Rank 2: 0.186152 ms.
Rank 3: 0.186387 ms.
Rank 4: 0.186543 ms.
Rank 5: 0.186256 ms.
Rank 6: 0.186184 ms.
Rank 7: 0.186235 ms.
Rank 8: 0.186311 ms.
Rank 9: 0.186251 ms.
Rank 10: 0.187033 ms.
Rank 11: 0.186261 ms.
Rank 12: 0.186173 ms.
Rank 13: 0.186353 ms.
Rank 14: 0.18614 ms.
Rank 15: 0.186162 ms.

Testing AllReduce with 1024 elements of F32
Rank 0: 0.172755 ms.
Rank 1: 0.172788 ms.
Rank 2: 0.17282 ms.
Rank 3: 0.172827 ms.
Rank 4: 0.172751 ms.
Rank 5: 0.172799 ms.
Rank 6: 0.172748 ms.
Rank 7: 0.172758 ms.
Rank 8: 0.172768 ms.
Rank 9: 0.172797 ms.
Rank 10: 0.172799 ms.
Rank 11: 0.17279 ms.
Rank 12: 0.172781 ms.
Rank 13: 0.172805 ms.
Rank 14: 0.172758 ms.
Rank 15: 0.172751 ms.

Testing AllReduce with 4096 elements of F32
Rank 0: 0.179455 ms.
Rank 1: 0.179454 ms.
Rank 2: 0.179455 ms.
Rank 3: 0.179475 ms.
Rank 4: 0.179449 ms.
Rank 5: 0.179456 ms.
Rank 6: 0.179471 ms.
Rank 7: 0.179479 ms.
Rank 8: 0.179444 ms.
Rank 9: 0.179448 ms.
Rank 10: 0.179451 ms.
Rank 11: 0.179432 ms.
Rank 12: 0.179516 ms.
Rank 13: 0.179644 ms.
Rank 14: 0.179465 ms.
Rank 15: 0.179459 ms.

Testing AllReduce with 8388608 elements of F32
Rank 0: 36.9271 ms.
Rank 1: 36.927 ms.
Rank 2: 36.926 ms.
Rank 3: 36.9271 ms.
Rank 4: 36.927 ms.
Rank 5: 36.9271 ms.
Rank 6: 36.9268 ms.
Rank 7: 36.9212 ms.
Rank 8: 36.9279 ms.
Rank 9: 36.9284 ms.
Rank 10: 36.9229 ms.
Rank 11: 36.9283 ms.
Rank 12: 36.924 ms.
Rank 13: 36.9301 ms.
Rank 14: 36.9357 ms.
Rank 15: 36.9271 ms.

Testing AllReduce with 128 elements of F16
Rank 0: 0.218922 ms.
Rank 1: 0.218942 ms.
Rank 2: 0.218952 ms.
Rank 3: 0.218922 ms.
Rank 4: 0.218933 ms.
Rank 5: 0.218934 ms.
Rank 6: 0.218958 ms.
Rank 7: 0.218913 ms.
Rank 8: 0.218875 ms.
Rank 9: 0.218894 ms.
Rank 10: 0.218897 ms.
Rank 11: 0.218912 ms.
Rank 12: 0.218911 ms.
Rank 13: 0.2189 ms.
Rank 14: 0.218928 ms.
Rank 15: 0.218902 ms.

Testing AllReduce with 1024 elements of F16
Rank 0: 0.207504 ms.
Rank 1: 0.207463 ms.
Rank 2: 0.207502 ms.
Rank 3: 0.207484 ms.
Rank 4: 0.207491 ms.
Rank 5: 0.207536 ms.
Rank 6: 0.207529 ms.
Rank 7: 0.20749 ms.
Rank 8: 0.207506 ms.
Rank 9: 0.207469 ms.
Rank 10: 0.207494 ms.
Rank 11: 0.207457 ms.
Rank 12: 0.207513 ms.
Rank 13: 0.207457 ms.
Rank 14: 0.207464 ms.
Rank 15: 0.207467 ms.

Testing AllReduce with 4096 elements of F16
Rank 0: 0.199163 ms.
Rank 1: 0.199138 ms.
Rank 2: 0.199178 ms.
Rank 3: 0.199119 ms.
Rank 4: 0.199183 ms.
Rank 5: 0.199135 ms.
Rank 6: 0.199138 ms.
Rank 7: 0.19913 ms.
Rank 8: 0.199146 ms.
Rank 9: 0.199196 ms.
Rank 10: 0.199156 ms.
Rank 11: 0.199167 ms.
Rank 12: 0.199154 ms.
Rank 13: 0.199162 ms.
Rank 14: 0.199132 ms.
Rank 15: 0.199153 ms.

Testing AllReduce with 8388608 elements of F16
Rank 0: 18.4486 ms.
Rank 1: 18.4486 ms.
Rank 2: 18.4487 ms.
Rank 3: 18.4486 ms.
Rank 4: 18.4486 ms.
Rank 5: 18.4462 ms.
Rank 6: 18.4483 ms.
Rank 7: 18.4486 ms.
Rank 8: 18.4487 ms.
Rank 9: 18.4487 ms.
Rank 10: 18.4466 ms.
Rank 11: 18.4481 ms.
Rank 12: 18.4454 ms.
Rank 13: 18.4493 ms.
Rank 14: 18.4288 ms.
Rank 15: 18.4487 ms.
```