### PR TITLE
Add support for BOOL/BF16 and printing utils in infiniop-test

### DIFF
--- a/src/infiniop-test/include/gguf.hpp
+++ b/src/infiniop-test/include/gguf.hpp
@@ -141,10 +141,8 @@ typedef enum {
 
 inline size_t ggmlTypeSize(GGML_TYPE ggml_type) {
     switch (ggml_type) {
-    case GGML_TYPE_F32:
-        return 4;
-    case GGML_TYPE_F16:
-        return 2;
+    case GGML_TYPE_Q8_K:
+        return 1;
     case GGML_TYPE_I8:
         return 1;
     case GGML_TYPE_I16:
@@ -153,10 +151,14 @@ inline size_t ggmlTypeSize(GGML_TYPE ggml_type) {
         return 4;
     case GGML_TYPE_I64:
         return 8;
-    case GGML_TYPE_F64:
-        return 8;
     case GGML_TYPE_BF16:
         return 2;
+    case GGML_TYPE_F16:
+        return 2;
+    case GGML_TYPE_F32:
+        return 4;
+    case GGML_TYPE_F64:
+        return 8;
     default:
         throw std::runtime_error("GGML_TYPE_SIZE: Unsupported GGML_TYPE");
     }

--- a/src/infiniop-test/include/tensor.hpp
+++ b/src/infiniop-test/include/tensor.hpp
@@ -6,6 +6,8 @@
 
 inline infiniDtype_t ggmlTypeToInfiniType(GGML_TYPE type) {
     switch (type) {
+    case GGML_TYPE_Q8_K:
+        return INFINI_DTYPE_BOOL;
     case GGML_TYPE_I8:
         return INFINI_DTYPE_I8;
     case GGML_TYPE_I16:

--- a/src/infiniop-test/include/utils.hpp
+++ b/src/infiniop-test/include/utils.hpp
@@ -17,6 +17,8 @@ inline double getVal(void *ptr, GGML_TYPE ggml_type) {
         return *(float *)ptr;
     case GGML_TYPE_F64:
         return *(double *)ptr;
+    case GGML_TYPE_Q8_K:
+        return *(bool *)ptr;
     case GGML_TYPE_I8:
         return *(int8_t *)ptr;
     case GGML_TYPE_I16:
@@ -40,6 +42,8 @@ inline size_t ggmlSizeOf(GGML_TYPE ggml_type) {
         return sizeof(float);
     case GGML_TYPE_F64:
         return sizeof(double);
+    case GGML_TYPE_Q8_K:
+        return sizeof(bool);
     case GGML_TYPE_I8:
         return sizeof(int8_t);
     case GGML_TYPE_I16:

--- a/src/infiniop-test/src/tensor.cpp
+++ b/src/infiniop-test/src/tensor.cpp
@@ -1,4 +1,5 @@
 #include "tensor.hpp"
+#include "gguf.hpp"
 #include "utils.hpp"
 #include <cstring>
 #include <infinirt.h>
@@ -273,6 +274,9 @@ void Tensor::debug() const {
     case GGML_TYPE_F64:
         printData((double *)(tensor->data()), _shape, _strides, 0);
         break;
+    case GGML_TYPE_Q8_K:
+        printData((bool *)(tensor->data()), _shape, _strides, 0);
+        break;
     case GGML_TYPE_I8:
         printData((int8_t *)(tensor->data()), _shape, _strides, 0);
         break;
@@ -281,6 +285,9 @@ void Tensor::debug() const {
         break;
     case GGML_TYPE_I32:
         printData((int32_t *)(tensor->data()), _shape, _strides, 0);
+        break;
+    case GGML_TYPE_I64:
+        printData((int64_t *)(tensor->data()), _shape, _strides, 0);
         break;
     default:
         std::cout << "Unsupported GGML type" << std::endl;

--- a/test/infiniop-test/test_generate/infiniop_test.py
+++ b/test/infiniop-test/test_generate/infiniop_test.py
@@ -9,12 +9,14 @@ from ml_dtypes import bfloat16
 def np_dtype_to_ggml(tensor_dtype: np.dtype):
     if tensor_dtype == bfloat16:
         return GGMLQuantizationType.BF16
-    if tensor_dtype == np.float16:
+    elif tensor_dtype == np.float16:
         return GGMLQuantizationType.F16
     elif tensor_dtype == np.float32:
         return GGMLQuantizationType.F32
     elif tensor_dtype == np.float64:
         return GGMLQuantizationType.F64
+    elif tensor_dtype == np.bool:
+        return GGMLQuantizationType.Q8_K
     elif tensor_dtype == np.int8:
         return GGMLQuantizationType.I8
     elif tensor_dtype == np.int16:
@@ -25,7 +27,7 @@ def np_dtype_to_ggml(tensor_dtype: np.dtype):
         return GGMLQuantizationType.I64
     else:
         raise ValueError(
-            "Only BF16, F16, F32, F64, I8, I16, I32, I64 tensors are supported for now"
+            "Only BF16, F16, F32, F64, BOOL, I8, I16, I32, I64 tensors are supported for now"
         )
 
 


### PR DESCRIPTION
本次PR实现以下改进：​​
- 新增对 int8_t、bf16_t、fp16_t 的标准化打印支持（[afb5b98](https://github.com/InfiniTensor/InfiniCore/pull/345/commits/afb5b98607c775e8d273ed06bb252613013df765)）
- 为 infiniop-test 添加 BF16 类型支持（[5c58f29](https://github.com/InfiniTensor/InfiniCore/pull/345/commits/5c58f29ca6fb43ee4e5a07750a3d40b7532b8583)）以及BOOL 类型支持（[c479901](https://github.com/InfiniTensor/InfiniCore/pull/345/commits/c4799013ceca7d4898ace9195ffce3f816f55320)）