### PR TITLE
issue/406: 修复 isMergable 的 stride 检查逻辑

### DIFF
--- a/src/infiniop/tensor_descriptor.cc
+++ b/src/infiniop/tensor_descriptor.cc
@@ -102,7 +102,7 @@ bool InfiniopTensorDescriptor::isMergable(size_t dim_start, size_t dim_end) cons
     auto ndim_ = shape_.size();
 
     for (size_t i = 1; i < ndim_; i++) {
-        if (stride(i - 1) != static_cast<ptrdiff_t>(dim(i)) * stride(i)) {
+        if (strides_[i - 1] != static_cast<ptrdiff_t>(shape_[i]) * strides_[i]) {
             return false;
         }
     }


### PR DESCRIPTION
应用过滤 dim=1 维度之后的 shape_ 和 strides_，修复 isMergable 的检查逻辑

<img width="1620" height="792" alt="image" src="https://github.com/user-attachments/assets/2d9c23d8-911a-44f4-9af6-6eea39287b4f" />
