### PR TITLE
issue/423: Improve the Precision of the PyTorch Implementation of `rms_norm`

### DIFF
--- a/test/infiniop/rms_norm.py
+++ b/test/infiniop/rms_norm.py
@@ -59,12 +59,10 @@ NUM_ITERATIONS = 1000
 
 
 def rms_norm(ans, x, w, eps):
-    torch.pow(x, 2, out=ans)
-    mean = torch.mean(ans, dim=-1, keepdim=True)
-    mean.add_(eps)
-    torch.rsqrt(mean, out=mean)
-    torch.mul(x, mean, out=ans)
-    ans.mul_(w)
+    input_dtype = x.dtype
+    hidden_states = x.to(torch.float32)
+    scale = hidden_states.pow(2).mean(-1, keepdim=True).add_(eps).rsqrt_()
+    ans.set_((hidden_states.mul_(scale).mul_(w)).to(input_dtype))
 
 
 def test(


### PR DESCRIPTION
- Fix the issue described in #423 by modifying the torch implementation to use fp32 for computation
- The precision increases but performance degrades, however, it is still better than the one before #264 

Screenshot for passing all the testcases on CPU (only part of the testcases are shown): 
<img width="904" height="341" alt="image" src="https://github.com/user-attachments/assets/a817c42d-4ac2-4cba-a1a3-b6fd11155ed1" />
