### PR TITLE
issue/469: disable NVIDIA-dequantize on Iluvatar GPU via ENABLE_NVIDIA_API marco

### DIFF
--- a/src/infiniop/ops/dequantize/nvidia/dequantize_w42f16_nvidia.cu
+++ b/src/infiniop/ops/dequantize/nvidia/dequantize_w42f16_nvidia.cu
@@ -1,3 +1,5 @@
+#ifdef ENABLE_NVIDIA_API
+
 #include "../../../devices/nvidia/nvidia_handle.cuh"
 #include "../../../devices/nvidia/nvidia_kernel_common.cuh"
 #include "dequantize_w42f16_kernel.cuh"
@@ -132,3 +134,5 @@ Descriptor::calculate(
 }
 
 } // namespace op::dequantize::nvidia
+
+#endif


### PR DESCRIPTION
通过宏定义避免天数平台对 NV 平台 PTX dequantize 代码复用导致的编译错误