### PR TITLE
issue/481: support more data type for rmsnorm in moore gpu

### DIFF
--- a/src/infiniop/ops/rms_norm/moore/rms_norm_moore.mu
+++ b/src/infiniop/ops/rms_norm/moore/rms_norm_moore.mu
@@ -77,10 +77,14 @@ infiniStatus_t launchKernel(
 
     if (atype == INFINI_DTYPE_F16 && wtype == INFINI_DTYPE_F16) {
         LAUNCH_KERNEL(half, half, float);
+    } else if (atype == INFINI_DTYPE_F16 && wtype == INFINI_DTYPE_BF16){
+        LAUNCH_KERNEL(half, __mt_bfloat16, float);
     } else if (atype == INFINI_DTYPE_F16 && wtype == INFINI_DTYPE_F32) {
         LAUNCH_KERNEL(half, float, float);
     } else if (atype == INFINI_DTYPE_BF16 && wtype == INFINI_DTYPE_BF16) {
         LAUNCH_KERNEL(__mt_bfloat16, __mt_bfloat16, float);
+    } else if (atype == INFINI_DTYPE_BF16 && wtype == INFINI_DTYPE_F16) {
+        LAUNCH_KERNEL(__mt_bfloat16, half, float);
     } else if (atype == INFINI_DTYPE_BF16 && wtype == INFINI_DTYPE_F32) {
         LAUNCH_KERNEL(__mt_bfloat16, float, float);
     } else if (atype == INFINI_DTYPE_F32 && wtype == INFINI_DTYPE_F32) {


### PR DESCRIPTION
rms_norm 的 python 前端测试添加 bfloat16 与 float16 等类型的数据组合，修改摩尔 rms_norm 后端实现适配更多测试数据组合。

python 测试截图：
<img width="2181" height="1629" alt="image" src="https://github.com/user-attachments/assets/3eb27032-0394-4e82-b7b1-275f2bd2a5fc" />
<img width="2347" height="1639" alt="image" src="https://github.com/user-attachments/assets/4c10fc72-a9e8-45a4-857b-1a2c62a476df" />
