### PR TITLE
Issue/602 - 给变量起个名字

### DIFF
--- a/test/infinicore/framework/tensor.py
+++ b/test/infinicore/framework/tensor.py
@@ -284,6 +284,7 @@ class TensorSpec:
         self.is_scalar = is_scalar
         self.init_mode = init_mode
         self.kwargs = kwargs
+        self.name = kwargs.get("name") if kwargs.get("name") else None
 
     @classmethod
     def from_tensor(
@@ -339,10 +340,17 @@ class TensorSpec:
         """Check if this spec represents a tensor input (not scalar)"""
         return not self.is_scalar
 
+    def fill_name(self, name):
+        if self.name is None:
+            self.name = name
+
     def __str__(self):
+        name_str = f"{self.name}: " if self.name else ""
         if self.is_scalar:
-            return f"scalar({self.value})"
+            return f"{name_str}scalar({self.value})"
         else:
             strides_str = f", strides={self.strides}" if self.strides else ""
-            dtype_str = f", dtype={self.dtype}" if self.dtype else ""
-            return f"tensor{self.shape}{strides_str}{dtype_str}"
+            dtype_str = (
+                f", {str(self.dtype).replace("infinicore.", "")}" if self.dtype else ""
+            )
+            return f"{name_str}tensor{self.shape}{strides_str}{dtype_str}"

--- a/test/infinicore/ops/add.py
+++ b/test/infinicore/ops/add.py
@@ -65,9 +65,9 @@ def parse_test_cases():
             tolerance = _TOLERANCE_MAP.get(dtype, {"atol": 0, "rtol": 1e-3})
 
             # Create typed tensor specs
-            a_spec = TensorSpec.from_tensor(shape, a_strides, dtype)
-            b_spec = TensorSpec.from_tensor(shape, b_strides, dtype)
-            c_spec = TensorSpec.from_tensor(shape, c_strides, dtype)
+            a_spec = TensorSpec.from_tensor(shape, a_strides, dtype, name="a")
+            b_spec = TensorSpec.from_tensor(shape, b_strides, dtype, name="b")
+            c_spec = TensorSpec.from_tensor(shape, c_strides, dtype, name="c")
 
             # Test Case 1: Out-of-place (return value)
             test_cases.append(


### PR DESCRIPTION
resolves #602 
depends on #595 

允许在创建TensorSpec时给arg起个名字；
默认会自动根据位置填充，所以无需修改现有脚本；


<img width="2452" height="485" alt="image" src="https://github.com/user-attachments/assets/7b8c4618-22e0-4adb-a26d-c8280d412fb5" />
<img width="2104" height="478" alt="image" src="https://github.com/user-attachments/assets/5f8a6abe-9bdf-4897-bd64-85f8833d0724" />
