### PR TITLE
issue/806 : InfiniCore v0.1.0 中修复摩尔平台 causal_softmax 的问题

### DIFF
--- a/src/infiniop/ops/causal_softmax/moore/causal_softmax_kernel.h
+++ b/src/infiniop/ops/causal_softmax/moore/causal_softmax_kernel.h
@@ -28,7 +28,7 @@ __device__ void causalSoftmaxKernel(
         //          1 | * * * ... * *   |
         //          2 | * * * ... * * * |
         //  height: 3  col_id->
-        if (width + blockIdx.x >= threadIdx.x + height) {
+        if (width + blockIdx.x >= col + height) {
             if constexpr (std::is_same_v<Tdata, half> || std::is_same_v<Tdata, cuda_bfloat16>) {
                 /*
                  * MUSA does not support CUDA's native `hexp` function.


### PR DESCRIPTION
restore causal_softmax error near 1024-size boundary  in InfiniCore v0.1.0， 参考https://github.com/InfiniTensor/InfiniCore/pull/748，测试截图：
<img width="2071" height="1690" alt="image" src="https://github.com/user-attachments/assets/0402914e-523d-4361-a607-b9617f771ce0" />
