### PR TITLE
[2025秋季][T1-2-1]ttaohe

### DIFF
--- a/src/infiniop/ops/rearrange/nvidia/rearrange_kernel.cuh
+++ b/src/infiniop/ops/rearrange/nvidia/rearrange_kernel.cuh
@@ -182,7 +182,7 @@ struct Constraint {
     DEFINE_REARRANGE_KERNEL(float1, constraint_num, block_array_size, grid_array_size) \
     DEFINE_REARRANGE_KERNEL(float2, constraint_num, block_array_size, grid_array_size) \
     DEFINE_REARRANGE_KERNEL(float4, constraint_num, block_array_size, grid_array_size) \
-    DEFINE_REARRANGE_KERNEL(double4, constraint_num, block_array_size, grid_array_size)
+    DEFINE_REARRANGE_KERNEL(double4_32a, constraint_num, block_array_size, grid_array_size)
 
 // 与 MAX_BLOCK_ARRAY_SIZE 和 MAX_GRID_ARRAY_SIZE 耦合，需要同时修改
 // 为1-6和1-6的所有组合生成内核
@@ -323,7 +323,7 @@ template __global__ void rearrange_dynamic_kernel<uchar2>(void *, const void *, 
 template __global__ void rearrange_dynamic_kernel<float1>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
 template __global__ void rearrange_dynamic_kernel<float2>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
 template __global__ void rearrange_dynamic_kernel<float4>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
-template __global__ void rearrange_dynamic_kernel<double4>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
+template __global__ void rearrange_dynamic_kernel<double4_32a>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
 
 // 准备参数结构体
 struct RearrangeParams {
@@ -371,7 +371,7 @@ utils::Result<void *> getRearrangeKernel(const RearrangeParams &params) {
         GET_REARRANGE_KERNEL(float4, block_array_size, grid_array_size, constraint_num);  \
         break;                                                                            \
     case 32:                                                                              \
-        GET_REARRANGE_KERNEL(double4, block_array_size, grid_array_size, constraint_num); \
+        GET_REARRANGE_KERNEL(double4_32a, block_array_size, grid_array_size, constraint_num); \
         break;                                                                            \
     default:                                                                              \
         return INFINI_STATUS_BAD_PARAM;                                                   \

--- a/src/infiniop/ops/rearrange/nvidia/rearrange_kernel.cuh
+++ b/src/infiniop/ops/rearrange/nvidia/rearrange_kernel.cuh
@@ -8,8 +8,8 @@
 #define ARRAY_TYPE_SIZE size_t
 
 // 与 DEFINE_KERNELS_BY_CONSTRAINT 耦合，需要同时修改
-#define MAX_BLOCK_ARRAY_SIZE 5
-#define MAX_GRID_ARRAY_SIZE 5
+#define MAX_BLOCK_ARRAY_SIZE 6
+#define MAX_GRID_ARRAY_SIZE 6
 
 template <int ArrSize, typename ArrayType>
 struct ArrayStruct {
@@ -185,32 +185,145 @@ struct Constraint {
     DEFINE_REARRANGE_KERNEL(double4, constraint_num, block_array_size, grid_array_size)
 
 // 与 MAX_BLOCK_ARRAY_SIZE 和 MAX_GRID_ARRAY_SIZE 耦合，需要同时修改
-// 为1-5和1-5的所有组合生成内核
+// 为1-6和1-6的所有组合生成内核
 DEFINE_KERNELS_BY_CONSTRAINT(1, 1)
 DEFINE_KERNELS_BY_CONSTRAINT(1, 2)
 DEFINE_KERNELS_BY_CONSTRAINT(1, 3)
 DEFINE_KERNELS_BY_CONSTRAINT(1, 4)
 DEFINE_KERNELS_BY_CONSTRAINT(1, 5)
+DEFINE_KERNELS_BY_CONSTRAINT(1, 6)
 DEFINE_KERNELS_BY_CONSTRAINT(2, 1)
 DEFINE_KERNELS_BY_CONSTRAINT(2, 2)
 DEFINE_KERNELS_BY_CONSTRAINT(2, 3)
 DEFINE_KERNELS_BY_CONSTRAINT(2, 4)
 DEFINE_KERNELS_BY_CONSTRAINT(2, 5)
+DEFINE_KERNELS_BY_CONSTRAINT(2, 6)
 DEFINE_KERNELS_BY_CONSTRAINT(3, 1)
 DEFINE_KERNELS_BY_CONSTRAINT(3, 2)
 DEFINE_KERNELS_BY_CONSTRAINT(3, 3)
 DEFINE_KERNELS_BY_CONSTRAINT(3, 4)
 DEFINE_KERNELS_BY_CONSTRAINT(3, 5)
+DEFINE_KERNELS_BY_CONSTRAINT(3, 6)
 DEFINE_KERNELS_BY_CONSTRAINT(4, 1)
 DEFINE_KERNELS_BY_CONSTRAINT(4, 2)
 DEFINE_KERNELS_BY_CONSTRAINT(4, 3)
 DEFINE_KERNELS_BY_CONSTRAINT(4, 4)
 DEFINE_KERNELS_BY_CONSTRAINT(4, 5)
+DEFINE_KERNELS_BY_CONSTRAINT(4, 6)
 DEFINE_KERNELS_BY_CONSTRAINT(5, 1)
 DEFINE_KERNELS_BY_CONSTRAINT(5, 2)
 DEFINE_KERNELS_BY_CONSTRAINT(5, 3)
 DEFINE_KERNELS_BY_CONSTRAINT(5, 4)
 DEFINE_KERNELS_BY_CONSTRAINT(5, 5)
+DEFINE_KERNELS_BY_CONSTRAINT(5, 6)
+DEFINE_KERNELS_BY_CONSTRAINT(6, 1)
+DEFINE_KERNELS_BY_CONSTRAINT(6, 2)
+DEFINE_KERNELS_BY_CONSTRAINT(6, 3)
+DEFINE_KERNELS_BY_CONSTRAINT(6, 4)
+DEFINE_KERNELS_BY_CONSTRAINT(6, 5)
+DEFINE_KERNELS_BY_CONSTRAINT(6, 6)
+
+// ==============================================================================
+// 动态Kernel - 支持任意维度的fallback实现
+// ==============================================================================
+
+template <typename Tmem_type>
+__global__ void rearrange_dynamic_kernel(
+    void *__restrict__ dst,
+    const void *__restrict__ src,
+    const size_t block_dim,
+    const size_t block_len_total,
+    const ARRAY_TYPE_SIZE *block_len,
+    const ARRAY_TYPE_STRIDE *src_block_stride,
+    const ARRAY_TYPE_STRIDE *dst_block_stride,
+    const size_t grid_dim,
+    const ARRAY_TYPE_SIZE *grid_len,
+    const ARRAY_TYPE_STRIDE *src_grid_stride,
+    const ARRAY_TYPE_STRIDE *dst_grid_stride,
+    const size_t constraint_num,
+    const Constraint<ARRAY_TYPE_SIZE> *constraints) {
+
+    size_t thread_idx = threadIdx.x;
+    if (thread_idx >= block_len_total) {
+        return;
+    }
+
+    // 使用共享内存存储grid级别的偏移量
+    __shared__ ptrdiff_t shared_src_offset;
+    __shared__ ptrdiff_t shared_dst_offset;
+    __shared__ ARRAY_TYPE_SIZE shared_constraints_grid_idx_multiple[2]; // 最多支持2个约束
+
+    // 第0号线程计算grid偏移
+    if (threadIdx.x == 0) {
+        ptrdiff_t src_offset = 0;
+        ptrdiff_t dst_offset = 0;
+        size_t remaining = blockIdx.x;
+
+        // 初始化约束
+        for (size_t j = 0; j < constraint_num && j < 2; j++) {
+            shared_constraints_grid_idx_multiple[j] = 0;
+        }
+
+        // 计算grid维度的偏移
+        for (int i = grid_dim - 1; i >= 0; i--) {
+            size_t idx = remaining % grid_len[i];
+            remaining /= grid_len[i];
+            src_offset += idx * src_grid_stride[i];
+            dst_offset += idx * dst_grid_stride[i];
+
+            // 处理约束
+            for (size_t j = 0; j < constraint_num && j < 2; j++) {
+                if (i == constraints[j].grid_idx) {
+                    shared_constraints_grid_idx_multiple[j] = idx * constraints[j].grid_div_block;
+                }
+            }
+        }
+
+        shared_src_offset = src_offset;
+        shared_dst_offset = dst_offset;
+    }
+
+    __syncthreads();
+
+    // 所有线程读取共享内存
+    ptrdiff_t src_offset = shared_src_offset;
+    ptrdiff_t dst_offset = shared_dst_offset;
+    ARRAY_TYPE_SIZE constraints_grid_idx_multiple[2];
+    for (size_t j = 0; j < constraint_num && j < 2; j++) {
+        constraints_grid_idx_multiple[j] = shared_constraints_grid_idx_multiple[j];
+    }
+
+    // 计算block维度的偏移
+    size_t remaining = thread_idx;
+    for (int i = block_dim - 1; i >= 0; i--) {
+        size_t idx = remaining % block_len[i];
+        remaining /= block_len[i];
+
+        src_offset += idx * src_block_stride[i];
+        dst_offset += idx * dst_block_stride[i];
+
+        // 检查约束
+        for (size_t j = 0; j < constraint_num && j < 2; j++) {
+            if (i == constraints[j].block_idx) {
+                if (constraints_grid_idx_multiple[j] + idx >= constraints[j].total_len) {
+                    return;
+                }
+            }
+        }
+    }
+
+    // 执行数据拷贝
+    *reinterpret_cast<Tmem_type *>(reinterpret_cast<char *>(dst) + dst_offset) =
+        *reinterpret_cast<const Tmem_type *>(reinterpret_cast<const char *>(src) + src_offset);
+}
+
+// 为不同的数据类型生成动态kernel的模板实例
+template __global__ void rearrange_dynamic_kernel<uchar1>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
+template __global__ void rearrange_dynamic_kernel<uchar2>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
+template __global__ void rearrange_dynamic_kernel<float1>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
+template __global__ void rearrange_dynamic_kernel<float2>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
+template __global__ void rearrange_dynamic_kernel<float4>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
+template __global__ void rearrange_dynamic_kernel<double4>(void *, const void *, const size_t, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const ARRAY_TYPE_SIZE *, const ARRAY_TYPE_STRIDE *, const ARRAY_TYPE_STRIDE *, const size_t, const Constraint<ARRAY_TYPE_SIZE> *);
 
 // 准备参数结构体
 struct RearrangeParams {
@@ -294,6 +407,9 @@ utils::Result<void *> getRearrangeKernel(const RearrangeParams &params) {
     case 5:                                                      \
         GET_REARRANGE_KERNEL_BY_CONSTRAINT(block_array_size, 5); \
         break;                                                   \
+    case 6:                                                      \
+        GET_REARRANGE_KERNEL_BY_CONSTRAINT(block_array_size, 6); \
+        break;                                                   \
     }
 
 #define GET_REARRANGE_KERNEL_BY_BLOCK_NUM    \
@@ -312,6 +428,9 @@ utils::Result<void *> getRearrangeKernel(const RearrangeParams &params) {
         break;                               \
     case 5:                                  \
         GET_REARRANGE_KERNEL_BY_GRID_NUM(5); \
+        break;                               \
+    case 6:                                  \
+        GET_REARRANGE_KERNEL_BY_GRID_NUM(6); \
         break;                               \
     }
 

--- a/src/infiniop/ops/rearrange/nvidia/rearrange_transpose_kernel.cuh
+++ b/src/infiniop/ops/rearrange/nvidia/rearrange_transpose_kernel.cuh
@@ -1,0 +1,213 @@
+#ifndef __REARRANGE_TRANSPOSE_KERNEL_CUH__
+#define __REARRANGE_TRANSPOSE_KERNEL_CUH__
+
+#include "../../../devices/nvidia/nvidia_common.cuh"
+#include "../../../devices/nvidia/nvidia_kernel_common.cuh"
+
+namespace op::rearrange::nvidia {
+
+// Shared memory tile大小配置
+// 使用32x32 tile以获得最佳bank conflict避免和性能
+constexpr int TILE_DIM = 32;
+constexpr int BLOCK_ROWS = 8;  // 每个线程处理多行以提高occupancy
+
+/**
+ * 转置模式信息结构
+ */
+struct TransposeInfo {
+    size_t ndim;              // 维度数
+    size_t total_elements;    // 总元素数
+    size_t element_size;      // 元素大小（字节）
+    
+    // 将多维索引展平的参数
+    std::vector<size_t> shape;
+    std::vector<ptrdiff_t> src_strides;  // 源stride（字节）
+    std::vector<ptrdiff_t> dst_strides;  // 目标stride（字节）
+};
+
+/**
+ * 2D转置kernel - 使用shared memory tiling
+ * 适用于简单的2D矩阵转置
+ */
+template <typename T>
+__global__ void transpose_2d_kernel_tiled(
+    T *__restrict__ dst,
+    const T *__restrict__ src,
+    size_t rows,
+    size_t cols,
+    ptrdiff_t src_row_stride,  // 以T为单位
+    ptrdiff_t src_col_stride,
+    ptrdiff_t dst_row_stride,
+    ptrdiff_t dst_col_stride) {
+    
+    __shared__ T tile[TILE_DIM][TILE_DIM + 1];  // +1 避免bank conflict
+    
+    // 计算全局坐标
+    size_t x = blockIdx.x * TILE_DIM + threadIdx.x;
+    size_t y = blockIdx.y * TILE_DIM + threadIdx.y;
+    
+    // 从源读取到shared memory（coalesced读取）
+    if (x < cols && y < rows) {
+        size_t src_idx = y * src_row_stride + x * src_col_stride;
+        tile[threadIdx.y][threadIdx.x] = src[src_idx];
+    }
+    
+    __syncthreads();
+    
+    // 转置后的坐标
+    x = blockIdx.y * TILE_DIM + threadIdx.x;
+    y = blockIdx.x * TILE_DIM + threadIdx.y;
+    
+    // 从shared memory写入到目标（coalesced写入）
+    if (x < rows && y < cols) {
+        size_t dst_idx = y * dst_row_stride + x * dst_col_stride;
+        dst[dst_idx] = tile[threadIdx.x][threadIdx.y];
+    }
+}
+
+/**
+ * 多维转置kernel - 通用版本
+ * 处理任意维度的行列主序转换
+ * 
+ * 策略：使用shared memory作为缓冲区，分批处理
+ */
+template <typename T, int TILE_SIZE = 32>
+__global__ void transpose_nd_kernel(
+    T *__restrict__ dst,
+    const T *__restrict__ src,
+    const size_t *shape,         // [ndim]
+    const ptrdiff_t *src_strides, // [ndim] 以T为单位
+    const ptrdiff_t *dst_strides, // [ndim] 以T为单位
+    size_t ndim,
+    size_t total_elements) {
+    
+    size_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+    
+    if (gid >= total_elements) {
+        return;
+    }
+    
+    // 计算多维索引
+    size_t remaining = gid;
+    size_t src_offset = 0;
+    size_t dst_offset = 0;
+    
+    // 使用局部数组存储中间结果以减少寄存器压力
+    size_t indices[8];  // 支持最多8维
+    
+    // 从线性索引计算多维索引
+    for (int i = ndim - 1; i >= 0; i--) {
+        indices[i] = remaining % shape[i];
+        remaining /= shape[i];
+    }
+    
+    // 计算源和目标偏移
+    for (size_t i = 0; i < ndim; i++) {
+        src_offset += indices[i] * src_strides[i];
+        dst_offset += indices[i] * dst_strides[i];
+    }
+    
+    // 执行拷贝
+    dst[dst_offset] = src[src_offset];
+}
+
+/**
+ * 向量化的多维转置kernel
+ * 当数据对齐时使用4元素向量化访问
+ */
+template <typename T>
+__global__ void transpose_nd_kernel_vec4(
+    T *__restrict__ dst,
+    const T *__restrict__ src,
+    const size_t *shape,
+    const ptrdiff_t *src_strides,
+    const ptrdiff_t *dst_strides,
+    size_t ndim,
+    size_t total_elements) {
+    
+    size_t gid = (blockIdx.x * blockDim.x + threadIdx.x) * 4;
+    
+    if (gid + 3 >= total_elements) {
+        // 处理边界情况
+        for (size_t i = gid; i < total_elements && i < gid + 4; i++) {
+            size_t remaining = i;
+            size_t src_offset = 0;
+            size_t dst_offset = 0;
+            
+            size_t indices[8];
+            for (int j = ndim - 1; j >= 0; j--) {
+                indices[j] = remaining % shape[j];
+                remaining /= shape[j];
+            }
+            
+            for (size_t j = 0; j < ndim; j++) {
+                src_offset += indices[j] * src_strides[j];
+                dst_offset += indices[j] * dst_strides[j];
+            }
+            
+            dst[dst_offset] = src[src_offset];
+        }
+        return;
+    }
+    
+    // 向量化处理4个元素
+    for (int k = 0; k < 4; k++) {
+        size_t i = gid + k;
+        size_t remaining = i;
+        size_t src_offset = 0;
+        size_t dst_offset = 0;
+        
+        size_t indices[8];
+        for (int j = ndim - 1; j >= 0; j--) {
+            indices[j] = remaining % shape[j];
+            remaining /= shape[j];
+        }
+        
+        for (size_t j = 0; j < ndim; j++) {
+            src_offset += indices[j] * src_strides[j];
+            dst_offset += indices[j] * dst_strides[j];
+        }
+        
+        dst[dst_offset] = src[src_offset];
+    }
+}
+
+/**
+ * 6D特化的转置kernel - 针对(3,4,50,50,5,7)这类case优化
+ * 使用更好的索引计算和cache策略
+ */
+template <typename T>
+__global__ void transpose_6d_kernel_optimized(
+    T *__restrict__ dst,
+    const T *__restrict__ src,
+    size_t d0, size_t d1, size_t d2, size_t d3, size_t d4, size_t d5,
+    ptrdiff_t s0, ptrdiff_t s1, ptrdiff_t s2, ptrdiff_t s3, ptrdiff_t s4, ptrdiff_t s5,
+    ptrdiff_t d_s0, ptrdiff_t d_s1, ptrdiff_t d_s2, ptrdiff_t d_s3, ptrdiff_t d_s4, ptrdiff_t d_s5,
+    size_t total_elements) {
+    
+    size_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+    
+    if (gid >= total_elements) {
+        return;
+    }
+    
+    // 手动展开索引计算以减少除法操作
+    size_t idx = gid;
+    size_t i5 = idx % d5; idx /= d5;
+    size_t i4 = idx % d4; idx /= d4;
+    size_t i3 = idx % d3; idx /= d3;
+    size_t i2 = idx % d2; idx /= d2;
+    size_t i1 = idx % d1; idx /= d1;
+    size_t i0 = idx;
+    
+    // 计算源和目标偏移
+    size_t src_offset = i0 * s0 + i1 * s1 + i2 * s2 + i3 * s3 + i4 * s4 + i5 * s5;
+    size_t dst_offset = i0 * d_s0 + i1 * d_s1 + i2 * d_s2 + i3 * d_s3 + i4 * d_s4 + i5 * d_s5;
+    
+    dst[dst_offset] = src[src_offset];
+}
+
+} // namespace op::rearrange::nvidia
+
+#endif // __REARRANGE_TRANSPOSE_KERNEL_CUH__
+

--- a/src/infiniop/ops/rearrange/nvidia/rearrange_transpose_kernel.cuh
+++ b/src/infiniop/ops/rearrange/nvidia/rearrange_transpose_kernel.cuh
@@ -11,6 +11,10 @@ namespace op::rearrange::nvidia {
 constexpr int TILE_DIM = 32;
 constexpr int BLOCK_ROWS = 8;  // 每个线程处理多行以提高occupancy
 
+// 小矩阵专用 tile 配置：降低 launch/同步开销
+constexpr int TILE_DIM_SMALL = 16;
+constexpr int BLOCK_ROWS_SMALL = 8;
+
 /**
  * 转置模式信息结构
  */
@@ -47,9 +51,14 @@ __global__ void transpose_2d_kernel_tiled(
     size_t y = blockIdx.y * TILE_DIM + threadIdx.y;
     
     // 从源读取到shared memory（coalesced读取）
-    if (x < cols && y < rows) {
-        size_t src_idx = y * src_row_stride + x * src_col_stride;
-        tile[threadIdx.y][threadIdx.x] = src[src_idx];
+    // 采用 BLOCK_ROWS 提升 occupancy：每个线程负责多行
+    #pragma unroll
+    for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
+        size_t yj = y + j;
+        if (x < cols && yj < rows) {
+            size_t src_idx = yj * src_row_stride + x * src_col_stride;
+            tile[threadIdx.y + j][threadIdx.x] = src[src_idx];
+        }
     }
     
     __syncthreads();
@@ -59,9 +68,123 @@ __global__ void transpose_2d_kernel_tiled(
     y = blockIdx.x * TILE_DIM + threadIdx.y;
     
     // 从shared memory写入到目标（coalesced写入）
-    if (x < rows && y < cols) {
-        size_t dst_idx = y * dst_row_stride + x * dst_col_stride;
-        dst[dst_idx] = tile[threadIdx.x][threadIdx.y];
+    #pragma unroll
+    for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
+        size_t yj = y + j;
+        if (x < rows && yj < cols) {
+            size_t dst_idx = yj * dst_row_stride + x * dst_col_stride;
+            dst[dst_idx] = tile[threadIdx.x][threadIdx.y + j];
+        }
+    }
+}
+
+/**
+ * 2D 转置 kernel（小矩阵版本，16x16 tile）
+ *
+ * 对于 100x100 这类矩阵，32x32 tile 的 block/smem/sync 开销占比更高；
+ * 16x16 tile 往往能更接近 PyTorch 的小矩阵性能。
+ */
+template <typename T>
+__global__ void transpose_2d_kernel_tiled_small(
+    T *__restrict__ dst,
+    const T *__restrict__ src,
+    size_t rows,
+    size_t cols,
+    ptrdiff_t src_row_stride,  // 以T为单位
+    ptrdiff_t src_col_stride,
+    ptrdiff_t dst_row_stride,
+    ptrdiff_t dst_col_stride) {
+
+    __shared__ T tile[TILE_DIM_SMALL][TILE_DIM_SMALL + 1];
+
+    size_t x = blockIdx.x * TILE_DIM_SMALL + threadIdx.x;
+    size_t y = blockIdx.y * TILE_DIM_SMALL + threadIdx.y;
+
+    #pragma unroll
+    for (int j = 0; j < TILE_DIM_SMALL; j += BLOCK_ROWS_SMALL) {
+        size_t yj = y + j;
+        if (x < cols && yj < rows) {
+            size_t src_idx = yj * src_row_stride + x * src_col_stride;
+            tile[threadIdx.y + j][threadIdx.x] = src[src_idx];
+        }
+    }
+
+    __syncthreads();
+
+    x = blockIdx.y * TILE_DIM_SMALL + threadIdx.x;
+    y = blockIdx.x * TILE_DIM_SMALL + threadIdx.y;
+
+    #pragma unroll
+    for (int j = 0; j < TILE_DIM_SMALL; j += BLOCK_ROWS_SMALL) {
+        size_t yj = y + j;
+        if (x < rows && yj < cols) {
+            size_t dst_idx = yj * dst_row_stride + x * dst_col_stride;
+            dst[dst_idx] = tile[threadIdx.x][threadIdx.y + j];
+        }
+    }
+}
+
+/**
+ * 2D 转置 kernel（unit==2 专用，2元素向量化）
+ *
+ * block.x=16，每线程处理两个相邻列（共覆盖 32 列），shared memory 仍为 32x(32+1)。
+ * 适用于 cols 为偶数且 src/dst 在列方向 stride=1 的典型 transpose（如 row<->col major）。
+ */
+__global__ void transpose_2d_kernel_tiled_u16x2(
+    uint16_t *__restrict__ dst,
+    const uint16_t *__restrict__ src,
+    size_t rows,
+    size_t cols,
+    ptrdiff_t src_row_stride,  // 以 uint16_t 为单位
+    ptrdiff_t src_col_stride,
+    ptrdiff_t dst_row_stride,
+    ptrdiff_t dst_col_stride) {
+
+    __shared__ uint16_t tile[TILE_DIM][TILE_DIM + 1];
+
+    // 每线程覆盖 2 列
+    size_t x = blockIdx.x * TILE_DIM + threadIdx.x * 2;
+    size_t y = blockIdx.y * TILE_DIM + threadIdx.y;
+
+    // Load: src -> tile
+    #pragma unroll
+    for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
+        size_t yj = y + j;
+        if (yj < rows) {
+            size_t x0 = x;
+            size_t x1 = x + 1;
+            if (x0 < cols) {
+                size_t src_idx0 = yj * src_row_stride + x0 * src_col_stride;
+                tile[threadIdx.y + j][threadIdx.x * 2] = src[src_idx0];
+            }
+            if (x1 < cols) {
+                size_t src_idx1 = yj * src_row_stride + x1 * src_col_stride;
+                tile[threadIdx.y + j][threadIdx.x * 2 + 1] = src[src_idx1];
+            }
+        }
+    }
+
+    __syncthreads();
+
+    // Store: tile^T -> dst
+    x = blockIdx.y * TILE_DIM + threadIdx.x * 2;
+    y = blockIdx.x * TILE_DIM + threadIdx.y;
+
+    #pragma unroll
+    for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
+        size_t yj = y + j;
+        if (yj < cols) {
+            size_t x0 = x;
+            size_t x1 = x + 1;
+            if (x0 < rows) {
+                size_t dst_idx0 = yj * dst_row_stride + x0 * dst_col_stride;
+                dst[dst_idx0] = tile[threadIdx.x * 2][threadIdx.y + j];
+            }
+            if (x1 < rows) {
+                size_t dst_idx1 = yj * dst_row_stride + x1 * dst_col_stride;
+                dst[dst_idx1] = tile[threadIdx.x * 2 + 1][threadIdx.y + j];
+            }
+        }
     }
 }
 
@@ -205,6 +328,177 @@ __global__ void transpose_6d_kernel_optimized(
     size_t dst_offset = i0 * d_s0 + i1 * d_s1 + i2 * d_s2 + i3 * d_s3 + i4 * d_s4 + i5 * d_s5;
     
     dst[dst_offset] = src[src_offset];
+}
+
+/**
+ * 6D 转置 kernel（增量进位版本）
+ *
+ * 关键点：每个线程处理 VEC 个连续的 gid。
+ * 只对第一个 gid 做 div/mod，后续用 +stride 和进位修正 offset，降低索引开销。
+ */
+template <typename T, int VEC = 4>
+__global__ void transpose_6d_kernel_inc(
+    T *__restrict__ dst,
+    const T *__restrict__ src,
+    size_t d0, size_t d1, size_t d2, size_t d3, size_t d4, size_t d5,
+    ptrdiff_t s0, ptrdiff_t s1, ptrdiff_t s2, ptrdiff_t s3, ptrdiff_t s4, ptrdiff_t s5,
+    ptrdiff_t t0, ptrdiff_t t1, ptrdiff_t t2, ptrdiff_t t3, ptrdiff_t t4, ptrdiff_t t5,
+    size_t total_elements) {
+
+    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+    size_t gid0 = tid * static_cast<size_t>(VEC);
+    if (gid0 >= total_elements) return;
+
+    // 先把 gid0 解成 6D index（这一步仍然需要 div/mod，但每线程只做一次）
+    size_t idx = gid0;
+    size_t i5 = idx % d5; idx /= d5;
+    size_t i4 = idx % d4; idx /= d4;
+    size_t i3 = idx % d3; idx /= d3;
+    size_t i2 = idx % d2; idx /= d2;
+    size_t i1 = idx % d1; idx /= d1;
+    size_t i0 = idx;
+
+    ptrdiff_t src_offset = static_cast<ptrdiff_t>(i0) * s0 +
+                           static_cast<ptrdiff_t>(i1) * s1 +
+                           static_cast<ptrdiff_t>(i2) * s2 +
+                           static_cast<ptrdiff_t>(i3) * s3 +
+                           static_cast<ptrdiff_t>(i4) * s4 +
+                           static_cast<ptrdiff_t>(i5) * s5;
+
+    ptrdiff_t dst_offset = static_cast<ptrdiff_t>(i0) * t0 +
+                           static_cast<ptrdiff_t>(i1) * t1 +
+                           static_cast<ptrdiff_t>(i2) * t2 +
+                           static_cast<ptrdiff_t>(i3) * t3 +
+                           static_cast<ptrdiff_t>(i4) * t4 +
+                           static_cast<ptrdiff_t>(i5) * t5;
+
+    #pragma unroll
+    for (int k = 0; k < VEC; ++k) {
+        size_t gid = gid0 + static_cast<size_t>(k);
+        if (gid >= total_elements) break;
+
+        dst[dst_offset] = src[src_offset];
+
+        // i5++ 以及进位（同时修正 src/dst offset）
+        i5 += 1;
+        src_offset += s5;
+        dst_offset += t5;
+
+        if (i5 == d5) {
+            i5 = 0;
+            src_offset += s4 - static_cast<ptrdiff_t>(d5) * s5;
+            dst_offset += t4 - static_cast<ptrdiff_t>(d5) * t5;
+            i4 += 1;
+
+            if (i4 == d4) {
+                i4 = 0;
+                src_offset += s3 - static_cast<ptrdiff_t>(d4) * s4;
+                dst_offset += t3 - static_cast<ptrdiff_t>(d4) * t4;
+                i3 += 1;
+
+                if (i3 == d3) {
+                    i3 = 0;
+                    src_offset += s2 - static_cast<ptrdiff_t>(d3) * s3;
+                    dst_offset += t2 - static_cast<ptrdiff_t>(d3) * t3;
+                    i2 += 1;
+
+                    if (i2 == d2) {
+                        i2 = 0;
+                        src_offset += s1 - static_cast<ptrdiff_t>(d2) * s2;
+                        dst_offset += t1 - static_cast<ptrdiff_t>(d2) * t2;
+                        i1 += 1;
+
+                        if (i1 == d1) {
+                            i1 = 0;
+                            src_offset += s0 - static_cast<ptrdiff_t>(d1) * s1;
+                            dst_offset += t0 - static_cast<ptrdiff_t>(d1) * t1;
+                            i0 += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 5D 转置 kernel（增量进位版本）
+ *
+ * 每线程处理 VEC 个连续 gid，只对第一个 gid 做 div/mod；
+ * 后续通过 +stride + 进位修正 offset，减少索引开销。
+ */
+template <typename T, int VEC = 4>
+__global__ void transpose_5d_kernel_inc(
+    T *__restrict__ dst,
+    const T *__restrict__ src,
+    size_t d0, size_t d1, size_t d2, size_t d3, size_t d4,
+    ptrdiff_t s0, ptrdiff_t s1, ptrdiff_t s2, ptrdiff_t s3, ptrdiff_t s4,
+    ptrdiff_t t0, ptrdiff_t t1, ptrdiff_t t2, ptrdiff_t t3, ptrdiff_t t4,
+    size_t total_elements) {
+
+    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+    size_t gid0 = tid * static_cast<size_t>(VEC);
+    if (gid0 >= total_elements) return;
+
+    size_t idx = gid0;
+    size_t i4 = idx % d4; idx /= d4;
+    size_t i3 = idx % d3; idx /= d3;
+    size_t i2 = idx % d2; idx /= d2;
+    size_t i1 = idx % d1; idx /= d1;
+    size_t i0 = idx;
+
+    ptrdiff_t src_offset = static_cast<ptrdiff_t>(i0) * s0 +
+                           static_cast<ptrdiff_t>(i1) * s1 +
+                           static_cast<ptrdiff_t>(i2) * s2 +
+                           static_cast<ptrdiff_t>(i3) * s3 +
+                           static_cast<ptrdiff_t>(i4) * s4;
+
+    ptrdiff_t dst_offset = static_cast<ptrdiff_t>(i0) * t0 +
+                           static_cast<ptrdiff_t>(i1) * t1 +
+                           static_cast<ptrdiff_t>(i2) * t2 +
+                           static_cast<ptrdiff_t>(i3) * t3 +
+                           static_cast<ptrdiff_t>(i4) * t4;
+
+    #pragma unroll
+    for (int k = 0; k < VEC; ++k) {
+        size_t gid = gid0 + static_cast<size_t>(k);
+        if (gid >= total_elements) break;
+
+        dst[dst_offset] = src[src_offset];
+
+        // i4++ and carry
+        i4 += 1;
+        src_offset += s4;
+        dst_offset += t4;
+
+        if (i4 == d4) {
+            i4 = 0;
+            src_offset += s3 - static_cast<ptrdiff_t>(d4) * s4;
+            dst_offset += t3 - static_cast<ptrdiff_t>(d4) * t4;
+            i3 += 1;
+
+            if (i3 == d3) {
+                i3 = 0;
+                src_offset += s2 - static_cast<ptrdiff_t>(d3) * s3;
+                dst_offset += t2 - static_cast<ptrdiff_t>(d3) * t3;
+                i2 += 1;
+
+                if (i2 == d2) {
+                    i2 = 0;
+                    src_offset += s1 - static_cast<ptrdiff_t>(d2) * s2;
+                    dst_offset += t1 - static_cast<ptrdiff_t>(d2) * t2;
+                    i1 += 1;
+
+                    if (i1 == d1) {
+                        i1 = 0;
+                        src_offset += s0 - static_cast<ptrdiff_t>(d1) * s1;
+                        dst_offset += t0 - static_cast<ptrdiff_t>(d1) * t1;
+                        i0 += 1;
+                    }
+                }
+            }
+        }
+    }
 }
 
 } // namespace op::rearrange::nvidia

--- a/test/infinicore/framework/utils.py
+++ b/test/infinicore/framework/utils.py
@@ -391,7 +391,8 @@ def rearrange_tensor(tensor, new_strides):
     new_positions += offset
 
     # Copy the original data to the new tensor
-    new_tensor.view(-1).index_add_(0, new_positions, tensor.view(-1))
+    # NOTE: tensor may be non-contiguous; use reshape instead of view.
+    new_tensor.reshape(-1).index_add_(0, new_positions, tensor.reshape(-1))
     new_tensor.set_(new_tensor.untyped_storage(), offset, shape, tuple(new_strides))
 
     return new_tensor


### PR DESCRIPTION
### PR 背景 / 动机
`rearrange` 在 NVIDIA 上遇到典型 **row-major ↔ col-major / full-transpose** 的 stride pattern 时，通用 kernel 存在严重的非合并访存 + 索引开销，导致在一些 case（尤其 6D/大 2D）明显落后 PyTorch。  
本 PR 引入 **pattern detection + 专用 transpose fast-path kernels + 保底 fallback**，对常见 transpose 类 case 提升显著，并保持不命中时回退到原通用实现。

### 主要改动
#### 1) NVIDIA `rearrange` 新增 transpose fast-path（带 fallback）
- 在 `Descriptor::calculate()` 中识别并优先尝试 fast-path：
  - **2D**：row-major ↔ col-major layout transform
  - **4D~6D**：full-transpose（stride order 反转）pattern
- fast-path 失败/不匹配则 **回退** 到既有 `prepareRearrangeParams + static/dynamic kernel` 路径，保证正确性。

涉及文件：
- `src/infiniop/ops/rearrange/nvidia/rearrange_nvidia.cu`

#### 2) 新增/增强 transpose kernels（2D / 5D / 6D）
新增专用 kernel 文件并持续扩展：
- `src/infiniop/ops/rearrange/nvidia/rearrange_transpose_kernel.cuh`

包含：
- **2D shared-memory tiled transpose**（32×32 tile，避免 bank conflict）
- **2D small-matrix 16×16 tile**：优化 100×100 这类小矩阵的 launch/sync 占比
- **6D VEC+carry kernel（F16/F32）**：每线程处理 4 个连续元素，减少 div/mod 索引开销（F16 用 `uint16_t` bitwise copy）
- **5D VEC+carry kernel（F16/F32）**：覆盖 `(3,4,7,53,9)` 这类中等规模 full-transpose

#### 3) 调整 full-transpose pattern 的启发式阈值
- `isFullTransposePattern()` 维持严格的 stride-order 反转判断
- 阈值按维度区分：让 5D case 可以命中，但总体仍然保守，避免小 case 误判带来回退开销/波动。

涉及文件：
- `src/infiniop/ops/rearrange/nvidia/rearrange_nvidia.cu`

#### 4) 测试/Benchmark 集成与修复
- 增加 `test/infinicore/ops/rearrange.py`，支持 `run.py --ops rearrange --bench` 跑功能与性能对比
- 调整为 **预分配 out + 只 copy_** 的 bench 方式，更贴近算子核心开销
- 修复测试框架里 `rearrange_tensor()` 对非 contiguous tensor 使用 `.view(-1)` 报错，改为 `.reshape(-1)`：
  - `test/infinicore/framework/utils.py`

### Benchmark（示例）
在 `srun --gres=gpu:nvidia:1 python test/infinicore/run.py --ops rearrange --nvidia --bench` 下：
- **(2000,2000) F16/F32**：显著快于 PyTorch（2D tiled fast-path 命中）
- **(3,4,50,50,5,7) F32**：由 6D VEC+carry fast-path 拉起（多数情况下可超过 PyTorch）
- **(3,4,7,53,9) F16/F32**：5D fast-path 基本追平或略优（视环境波动）
<img width="477" height="300" alt="TEST SUMMARY" src="https://github.com/user-attachments/assets/da70684e-76a3-4948-b36d-61bf860b7666" />
<img width="593" height="358" alt="CUMULATIVE TEST SUMMARY" src="https://github.com/user-attachments/assets/250901fc-4ecd-476e-b4a3-3e6c45a53ae5" />


### 如何构建 & 复现
```bash
# 编译安装 C++/CUDA
xmake build infiniop && xmake install infiniop

# 运行单算子 bench（device timing）
srun --gres=gpu:nvidia:1 --cpus-per-task=16 --mem=256G \
  python test/infinicore/run.py --ops rearrange --nvidia --bench
```

### 风险与回退策略
- fast-path **仅在严格 pattern 匹配**时启用；否则自动 fallback
- kernel launch 失败会返回错误并回退到原通用实现（避免影响正确性）
- 小矩阵采用小 tile，降低 overhead；大矩阵保持 32×32 tile

### HONER_CODE.md
[HONOR_CODE.md](https://github.com/user-attachments/files/24268538/HONOR_CODE.md)

### REFERENCE.md
[REFERENCE.md](https://github.com/user-attachments/files/24268548/REFERENCE.md)

