### PR TITLE
issue/853 - Bug fix: import TestCase and utils class from new file

### DIFF
--- a/test/infinicore/nn/embedding.py
+++ b/test/infinicore/nn/embedding.py
@@ -4,11 +4,15 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import torch
-from framework.base import BaseOperatorTest, TensorSpec
-from framework.entities import TestCase
-from framework.runner import GenericTestRunner
-from framework.tensor import TensorInitializer
-from framework.utils.tensor_utils import convert_infinicore_to_torch
+
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorInitializer,
+    TensorSpec,
+    TestCase,
+    convert_infinicore_to_torch,
+)
 
 import infinicore
 

--- a/test/infinicore/nn/linear.py
+++ b/test/infinicore/nn/linear.py
@@ -4,9 +4,13 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import torch
-from framework.base import BaseOperatorTest, TensorSpec
-from framework.entities import TestCase
-from framework.runner import GenericTestRunner
+
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorSpec,
+    TestCase
+)
 
 import infinicore
 

--- a/test/infinicore/nn/rmsnorm.py
+++ b/test/infinicore/nn/rmsnorm.py
@@ -4,9 +4,13 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import torch
-from framework.base import BaseOperatorTest, TensorSpec
-from framework.entities import TestCase
-from framework.runner import GenericTestRunner
+
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorSpec,
+    TestCase
+)
 
 import infinicore
 

--- a/test/infinicore/nn/rope.py
+++ b/test/infinicore/nn/rope.py
@@ -4,9 +4,13 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import torch
-from framework.base import BaseOperatorTest, TensorSpec
-from framework.entities import TestCase
-from framework.runner import GenericTestRunner
+
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorSpec,
+    TestCase
+)
 from infinicore.nn.functional import RopeAlgo
 
 import infinicore

--- a/test/infinicore/tensor/narrow.py
+++ b/test/infinicore/tensor/narrow.py
@@ -5,10 +5,15 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import torch
 import infinicore
-from framework.base import BaseOperatorTest, TensorSpec
-from framework.entities import TestCase
-from framework.runner import GenericTestRunner
-from framework.utils.tensor_utils import is_broadcast
+
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    is_broadcast,
+    TensorSpec,
+    TestCase
+)
+
 
 # ==============================================================================
 # Operator-specific configuration

--- a/test/infinicore/tensor/squeeze.py
+++ b/test/infinicore/tensor/squeeze.py
@@ -5,10 +5,15 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import torch
 import infinicore
-from framework.base import BaseOperatorTest, TensorSpec
-from framework.entities import TestCase
-from framework.runner import GenericTestRunner
-from framework.utils.tensor_utils import is_broadcast
+
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorSpec,
+    TestCase,
+    is_broadcast
+)
+
 
 # ==============================================================================
 # Operator-specific configuration

--- a/test/infinicore/tensor/unsqueeze.py
+++ b/test/infinicore/tensor/unsqueeze.py
@@ -5,10 +5,15 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import torch
 import infinicore
-from framework.base import BaseOperatorTest, TensorSpec
-from framework.entities import TestCase
-from framework.runner import GenericTestRunner
-from framework.utils.tensor_utils import is_broadcast
+
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorSpec,
+    TestCase,
+    is_broadcast
+)
+
 
 # ==============================================================================
 # Operator-specific configuration


### PR DESCRIPTION
## Description
Bug fix: import TestCase and utils class from new file

## Test evidence
test command:
python test/infinicore/run.py --ops-dir test/infinicore/nn --nvidia
python test/infinicore/run.py --ops-dir test/infinicore/tensor --nvidia
python test/infinicore/nn/parameter.py
python test/infinicore/nn/module.py
python test/infinicore/nn/moduleList.py
```
python test/infinicore/run.py --ops-dir test/infinicore/tensor --nvidia
InfiniCore Operator Test Runner
Directory: test/infinicore/tensor
Tests found: 3

✅  unsqueeze: PASSED (code: 0)

============================================================
Testing unsqueeze on NVIDIA
============================================================
TestCase(unsqueeze - inputs=[in_0: tensor(1, 1, 1), float16; 1])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 1, 1), bfloat16; 1])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 1, 1), float32; 1])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 1, 1), float16; 0])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 1, 1), bfloat16; 0])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 1, 1), float32; 0])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 2, 4), float16; 0])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 2, 4), bfloat16; 0])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 2, 4), float32; 0])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(2, 1, 4), strides=(4, 0, 1), float16; 1])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(2, 1, 4), strides=(4, 0, 1), bfloat16; 1])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(2, 1, 4), strides=(4, 0, 1), float32; 1])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 4, 1, 32), strides=(32, 32, 32, 1), float16; 2])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 4, 1, 32), strides=(32, 32, 32, 1), bfloat16; 2])
✓ Passed
TestCase(unsqueeze - inputs=[in_0: tensor(1, 4, 1, 32), strides=(32, 32, 32, 1), float32; 2])
✓ Passed

============================================================
TEST SUMMARY
Total tests: 15
Passed: 15
Success rate: 100.0%

All tests passed!
============================================================
----------------------------------------
✅  squeeze: PASSED (code: 0)

============================================================
Testing squeeze on NVIDIA
============================================================
TestCase(squeeze - inputs=[in_0: tensor(1, 1, 1), float16; 1])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 1, 1), bfloat16; 1])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 1, 1), float32; 1])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 1, 1), float16; 0])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 1, 1), bfloat16; 0])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 1, 1), float32; 0])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 2, 4), float16; 0])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 2, 4), bfloat16; 0])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 2, 4), float32; 0])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(2, 1, 4), strides=(4, 0, 1), float16; 1])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(2, 1, 4), strides=(4, 0, 1), bfloat16; 1])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(2, 1, 4), strides=(4, 0, 1), float32; 1])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 4, 1, 32), strides=(32, 32, 32, 1), float16; 2])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 4, 1, 32), strides=(32, 32, 32, 1), bfloat16; 2])
✓ Passed
TestCase(squeeze - inputs=[in_0: tensor(1, 4, 1, 32), strides=(32, 32, 32, 1), float32; 2])
✓ Passed

============================================================
TEST SUMMARY
Total tests: 15
Passed: 15
Success rate: 100.0%

All tests passed!
============================================================
----------------------------------------
✅  narrow: PASSED (code: 0)

============================================================
Testing Narrow on NVIDIA
============================================================
TestCase(Narrow - inputs=[in_0: tensor(2, 4), float16; 0; 0; 1])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(2, 4), bfloat16; 0; 0; 1])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(2, 4), float32; 0; 0; 1])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(2, 4), float16; 1; 1; 1])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(2, 4), bfloat16; 1; 1; 1])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(2, 4), float32; 1; 1; 1])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(5, 3, 2), float16; 1; 0; 3])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(5, 3, 2), bfloat16; 1; 0; 3])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(5, 3, 2), float32; 1; 0; 3])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(5, 3, 2), float16; 0; 1; 3])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(5, 3, 2), bfloat16; 0; 1; 3])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(5, 3, 2), float32; 0; 1; 3])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(4, 4, 1024, 32), float16; 2; 1023; 1])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(4, 4, 1024, 32), bfloat16; 2; 1023; 1])
✓ Passed
TestCase(Narrow - inputs=[in_0: tensor(4, 4, 1024, 32), float32; 2; 1023; 1])
✓ Passed

============================================================
TEST SUMMARY
Total tests: 15
Passed: 15
Success rate: 100.0%

All tests passed!
============================================================
----------------------------------------

================================================================================
CUMULATIVE TEST SUMMARY
================================================================================
Total tests run: 3
Passed: 3
Failed: 0

✅ PASSED OPERATORS (3):
  unsqueeze, squeeze, narrow

Success rate: 100.0%

🎉 All tests passed!
-----------------------------------------------------------------------------------------------------------------------------------------------
python test/infinicore/run.py --ops-dir test/infinicore/nn --nvidia           
InfiniCore Operator Test Runner
Directory: test/infinicore/nn
Tests found: 4

✅  linear: PASSED (code: 0)

============================================================
Testing nn.Linear on NVIDIA
============================================================
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(1, 10), float16; weight: tensor(2, 10), float16; bias: tensor(2,), float16], kwargs={has_bias=True})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(1, 10), bfloat16; weight: tensor(2, 10), bfloat16; bias: tensor(2,), bfloat16], kwargs={has_bias=True})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(1, 10), float32; weight: tensor(2, 10), float32; bias: tensor(2,), float32], kwargs={has_bias=True})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(4, 10), float16; weight: tensor(2, 10), float16; bias: tensor(2,), float16], kwargs={has_bias=False})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(4, 10), bfloat16; weight: tensor(2, 10), bfloat16; bias: tensor(2,), bfloat16], kwargs={has_bias=False})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(4, 10), float32; weight: tensor(2, 10), float32; bias: tensor(2,), float32], kwargs={has_bias=False})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(1, 1024), float16; weight: tensor(3072, 1024), float16; bias: tensor(3072,), float16], kwargs={has_bias=True})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(1, 1024), bfloat16; weight: tensor(3072, 1024), bfloat16; bias: tensor(3072,), bfloat16], kwargs={has_bias=True})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(1, 1024), float32; weight: tensor(3072, 1024), float32; bias: tensor(3072,), float32], kwargs={has_bias=True})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(5, 1024), float16; weight: tensor(3072, 1024), float16; bias: tensor(3072,), float16], kwargs={has_bias=False})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(5, 1024), bfloat16; weight: tensor(3072, 1024), bfloat16; bias: tensor(3072,), bfloat16], kwargs={has_bias=False})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(5, 1024), float32; weight: tensor(3072, 1024), float32; bias: tensor(3072,), float32], kwargs={has_bias=False})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(2, 5, 1024), float16; weight: tensor(3072, 1024), float16; bias: tensor(3072,), float16], kwargs={has_bias=True})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(2, 5, 1024), bfloat16; weight: tensor(3072, 1024), bfloat16; bias: tensor(3072,), bfloat16], kwargs={has_bias=True})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(2, 5, 1024), float32; weight: tensor(3072, 1024), float32; bias: tensor(3072,), float32], kwargs={has_bias=True})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(10, 5, 1024), float16; weight: tensor(3072, 1024), float16; bias: tensor(3072,), float16], kwargs={has_bias=False})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(10, 5, 1024), bfloat16; weight: tensor(3072, 1024), bfloat16; bias: tensor(3072,), bfloat16], kwargs={has_bias=False})
✓ Passed
TestCase(nn.Linear - OUT_OF_PLACE - inputs=[x: tensor(10, 5, 1024), float32; weight: tensor(3072, 1024), float32; bias: tensor(3072,), float32], kwargs={has_bias=False})
✓ Passed

============================================================
TEST SUMMARY
Total tests: 18
Passed: 18
Success rate: 100.0%

All tests passed!
============================================================
----------------------------------------
✅  rmsnorm: PASSED (code: 0)

============================================================
Testing nn.RMSNorm on NVIDIA
============================================================
TestCase(nn.RMSNorm - OUT_OF_PLACE - inputs=[x: tensor(1, 8), float16; weight: tensor(8,), float16])
✓ Passed
TestCase(nn.RMSNorm - OUT_OF_PLACE - inputs=[x: tensor(1, 8), bfloat16; weight: tensor(8,), bfloat16])
✓ Passed
TestCase(nn.RMSNorm - OUT_OF_PLACE - inputs=[x: tensor(1, 8), float32; weight: tensor(8,), float32])
✓ Passed
TestCase(nn.RMSNorm - OUT_OF_PLACE - inputs=[x: tensor(2, 3, 8), float16; weight: tensor(8,), float16])
✓ Passed
TestCase(nn.RMSNorm - OUT_OF_PLACE - inputs=[x: tensor(2, 3, 8), bfloat16; weight: tensor(8,), bfloat16])
✓ Passed
TestCase(nn.RMSNorm - OUT_OF_PLACE - inputs=[x: tensor(2, 3, 8), float32; weight: tensor(8,), float32])
✓ Passed
TestCase(nn.RMSNorm - OUT_OF_PLACE - inputs=[x: tensor(2, 10, 64), float16; weight: tensor(64,), float16])
✓ Passed
TestCase(nn.RMSNorm - OUT_OF_PLACE - inputs=[x: tensor(2, 10, 64), bfloat16; weight: tensor(64,), bfloat16])
✓ Passed
TestCase(nn.RMSNorm - OUT_OF_PLACE - inputs=[x: tensor(2, 10, 64), float32; weight: tensor(64,), float32])
✓ Passed

============================================================
TEST SUMMARY
Total tests: 9
Passed: 9
Success rate: 100.0%

All tests passed!
============================================================
----------------------------------------
✅  rope: PASSED (code: 0)

============================================================
Testing nn.RoPE on NVIDIA
============================================================
TestCase(nn.RoPE - OUT_OF_PLACE - inputs=[x: tensor[1, 10, 32, 64], float16], kwargs={max_position_embeddings=1024; rope_theta=10000.0})
✓ Passed
TestCase(nn.RoPE - OUT_OF_PLACE - inputs=[x: tensor[1, 10, 32, 64], float32], kwargs={max_position_embeddings=1024; rope_theta=10000.0})
✓ Passed
TestCase(nn.RoPE - OUT_OF_PLACE - inputs=[x: tensor[2, 2, 32, 64], float16], kwargs={max_position_embeddings=1024; rope_theta=10000.0})
✓ Passed
TestCase(nn.RoPE - OUT_OF_PLACE - inputs=[x: tensor[2, 2, 32, 64], float32], kwargs={max_position_embeddings=1024; rope_theta=10000.0})
✓ Passed
TestCase(nn.RoPE - OUT_OF_PLACE - inputs=[x: tensor[5, 10, 32, 64], float16], kwargs={max_position_embeddings=1024; rope_theta=10000.0})
✓ Passed
TestCase(nn.RoPE - OUT_OF_PLACE - inputs=[x: tensor[5, 10, 32, 64], float32], kwargs={max_position_embeddings=1024; rope_theta=10000.0})
✓ Passed

============================================================
TEST SUMMARY
Total tests: 6
Passed: 6
Success rate: 100.0%

All tests passed!
============================================================
----------------------------------------
✅  embedding: PASSED (code: 0)

============================================================
Testing nn.Embedding on NVIDIA
============================================================
TestCase(nn.Embedding - OUT_OF_PLACE - inputs=[x: tensor(1, 5), int64; weight: tensor(32000, 2048), float16])
✓ Passed
TestCase(nn.Embedding - OUT_OF_PLACE - inputs=[x: tensor(1, 5), int64; weight: tensor(32000, 2048), bfloat16])
✓ Passed
TestCase(nn.Embedding - OUT_OF_PLACE - inputs=[x: tensor(1, 5), int64; weight: tensor(32000, 2048), float32])
✓ Passed
TestCase(nn.Embedding - OUT_OF_PLACE - inputs=[x: tensor(2, 5), int64; weight: tensor(32000, 2048), float16])
✓ Passed
TestCase(nn.Embedding - OUT_OF_PLACE - inputs=[x: tensor(2, 5), int64; weight: tensor(32000, 2048), bfloat16])
✓ Passed
TestCase(nn.Embedding - OUT_OF_PLACE - inputs=[x: tensor(2, 5), int64; weight: tensor(32000, 2048), float32])
✓ Passed
TestCase(nn.Embedding - OUT_OF_PLACE - inputs=[x: tensor(2, 2, 5), int64; weight: tensor(32000, 2048), float16])
✓ Passed
TestCase(nn.Embedding - OUT_OF_PLACE - inputs=[x: tensor(2, 2, 5), int64; weight: tensor(32000, 2048), bfloat16])
✓ Passed
TestCase(nn.Embedding - OUT_OF_PLACE - inputs=[x: tensor(2, 2, 5), int64; weight: tensor(32000, 2048), float32])
✓ Passed

============================================================
TEST SUMMARY
Total tests: 9
Passed: 9
Success rate: 100.0%

All tests passed!
============================================================
----------------------------------------

================================================================================
CUMULATIVE TEST SUMMARY
================================================================================
Total tests run: 4
Passed: 4
Failed: 0

✅ PASSED OPERATORS (4):
  linear, rmsnorm, rope, embedding

Success rate: 100.0%

🎉 All tests passed!

python test/infinicore/nn/parameter.py 
param 'a' don't match input_param 'a'
InfiniCoreModule 与 Torch (CPU) 最大误差: 手动查看 
Tensor: shape[ 1 2 3 ] strides[ 6 3 1 ] dtype=F32 device=NVIDIA:0
0 0 0 
0 0 0 
Tensor: shape[ 1 2 3 ] strides[ 6 3 1 ] dtype=F32 device=NVIDIA:0
0 0 0 
0 0 0 

=== 测试 Parameter 基本功能 ===
✓ 创建 Parameter，形状: [1, 2, 3]
✓ 自动注册到 Module，参数数量: 2
✓ 参数可以通过属性访问
✓ state_dict 键数量: 2
✓ state_dict 键: ['weight', 'bias']
✓ __repr__ 方法: 输出包含类名
Parameter containing:
<infinicore.nn.parameter.InfiniCoreParameter object at 0x7fd1e6756850>...

=== 所有测试通过! ===

(base) ➜  InfiniCore git:(issue/853) ✗ python test/infinicore/nn/module.py   
InfiniCoreModule 与 Torch (CPU) 最大误差: 手动查看 
Tensor: shape[ 1 2 3 ] strides[ 6 3 1 ] dtype=F32 device=NVIDIA:0
0 0 0 
0 0 0 
Tensor: shape[ 1 2 3 ] strides[ 6 3 1 ] dtype=F32 device=NVIDIA:0
0 0 0 
0 0 0 
(base) ➜  InfiniCore git:(issue/853) ✗ python test/infinicore/nn/moduleList.py
```