### PR TITLE
issue/860: 在 `include/infinicore/ops.hpp` 中加入 `#include "ops/random_sample.hpp"`

### DIFF
--- a/include/infinicore/ops.hpp
+++ b/include/infinicore/ops.hpp
@@ -5,6 +5,7 @@
 #include "ops/causal_softmax.hpp"
 #include "ops/matmul.hpp"
 #include "ops/ones.hpp"
+#include "ops/random_sample.hpp"
 #include "ops/rearrange.hpp"
 #include "ops/rms_norm.hpp"
 #include "ops/rope.hpp"


### PR DESCRIPTION
`xmake build && xmake install && xmake build _infinicore && xmake install _infinicore && pip install -e . && python ./test/infinicore/ops/matmul.py --nvidia` 正常通过：

<img width="914" height="261" alt="image" src="https://github.com/user-attachments/assets/54ac3f71-1f99-4081-ba2b-d60cec6ebe10" />
