### PR TITLE
issue/892-添加infinicore.tensor函数; 移除from_numpy函数的dtype参数

### DIFF
--- a/python/infinicore/__init__.py
+++ b/python/infinicore/__init__.py
@@ -62,6 +62,7 @@ from infinicore.tensor import (
     ones,
     strided_empty,
     strided_from_blob,
+    tensor,
     zeros,
 )
 
@@ -127,6 +128,7 @@ __all__ = [
     "ones",
     "strided_empty",
     "strided_from_blob",
+    "tensor",
     "zeros",
 ]
 

--- a/python/infinicore/nn/modules/rope.py
+++ b/python/infinicore/nn/modules/rope.py
@@ -4,6 +4,7 @@ import infinicore
 from infinicore.nn import functional as F
 
 from ...tensor import Tensor
+from ...utils import infinicore_to_numpy_dtype
 from ..functional import RopeAlgo
 from .module import InfiniCoreModule as Module
 
@@ -31,8 +32,13 @@ def create_sin_cos_table(
         max_position, head_dim, theta
     )
 
-    sin_table_infini = infinicore.from_numpy(sin_table_np, dtype=dtype, device=device)
-    cos_table_infini = infinicore.from_numpy(cos_table_np, dtype=dtype, device=device)
+    if dtype is not None:
+        np_dtype = infinicore_to_numpy_dtype(dtype)
+        sin_table_np = sin_table_np.astype(np_dtype)
+        cos_table_np = cos_table_np.astype(np_dtype)
+
+    sin_table_infini = infinicore.from_numpy(sin_table_np, device=device)
+    cos_table_infini = infinicore.from_numpy(cos_table_np, device=device)
 
     return sin_table_infini, cos_table_infini
 

--- a/python/infinicore/tensor.py
+++ b/python/infinicore/tensor.py
@@ -1,4 +1,5 @@
 import ctypes
+from typing import Any, Union
 
 import numpy as np
 
@@ -17,15 +18,18 @@ class Tensor:
     # Public attributes describing the Tensor
     _underlying: _infinicore.Tensor
     _torch_ref: "torch.Tensor"  # noqa: F821
+    _numpy_ref: np.ndarray  # noqa: F821
+
     shape: list[int]
     dtype: infinicore.dtype
     device: infinicore.device
 
-    def __init__(self, underlying, *, _torch_ref=None):
+    def __init__(self, underlying, *, _torch_ref=None, _numpy_ref=None):
         """An internal method. Please do not use this directly."""
 
         self._underlying = underlying
         self._torch_ref = _torch_ref
+        self._numpy_ref = _numpy_ref
 
     def __getattr__(self, name):
         # Lazily construct and cache an attribute.
@@ -131,6 +135,38 @@ class Tensor:
         return infinicore.narrow(self, dim, start, length)
 
 
+def tensor(
+    data: Any,
+    *,
+    dtype: Union[infinicore.dtype, None] = None,
+    device: Union[infinicore.device, str, int, None] = None,
+    pin_memory: bool = False,
+) -> Tensor:
+    r"""
+    Constructs a tensor by copying `data`.
+
+    Args:
+        data (array_like): Initial data for the tensor. Can be a list, tuple, NumPy, scalar.
+
+    Keyword args:
+        dtype (infinicore.dtype, optional): the desired data type of returned tensor.
+            Default: if ``None``, infers data type from :attr:`data`.
+        device (infinicore.device, optional): the device of the constructed tensor.
+    """
+
+    if isinstance(data, (list, tuple)):
+        return from_list(data, dtype=dtype, device=device)
+    elif isinstance(data, np.ndarray):
+        if dtype is not None:
+            np_dtype = infinicore_to_numpy_dtype(dtype)
+            data = data.astype(np_dtype)
+        return from_numpy(data, device=device)
+    elif isinstance(data, (int, float)):
+        return from_list([data], dtype=dtype, device=device).squeeze(0)
+
+    raise ValueError(f" Can not convert data type: {type(data)} to Tensor")
+
+
 def empty(size, *, dtype=None, device=None, pin_memory=False):
     return Tensor(
         _infinicore.empty(size, dtype._underlying, device._underlying, pin_memory)
@@ -198,14 +234,13 @@ def from_torch(torch_tensor) -> Tensor:
 def from_numpy(
     np_array,
     *,
-    dtype: infinicore.dtype = None,
     device: infinicore.device = None,
 ) -> Tensor:
-    """Convert a NumPy ndarray to an infinicore Tensor.
+    """
+    Creates a Tensor from a numpy.ndarray.
 
     Args:
         np_array: NumPy ndarray to convert to tensor
-        dtype: Optional infinicore dtype. If None, inferred from numpy array
         device: Optional infinicore device. If None, defaults to CPU device
 
     Returns:
@@ -213,13 +248,13 @@ def from_numpy(
 
     Raises:
         TypeError: If input data is not a numpy ndarray
-        ValueError: If input array is empty
+        ValueError: If input array is empty or not C-contiguous
 
     Note:
         NumPy arrays can only be created on CPU. For CUDA devices, data is first
         created on CPU, then copied to the target device.
     """
-    # Input validation
+
     if not isinstance(np_array, np.ndarray):
         raise TypeError(
             f"Input data must be a np.ndarray, got {type(np_array).__name__}"
@@ -228,55 +263,29 @@ def from_numpy(
     if np_array.size == 0:
         raise ValueError("Input array cannot be empty")
 
-    # Determine target numpy dtype
-    # If dtype is specified, convert it to numpy dtype first
-    if dtype is not None:
-        np_dtype = infinicore_to_numpy_dtype(dtype)
-        # Create a copy with the target dtype if dtype doesn't match
-        # Use copy=True to ensure we don't modify the original array
-        if np_dtype != np_array.dtype:
-            np_array = np_array.astype(np_dtype, copy=True)
-        # Ensure C-contiguous layout
-        elif not np_array.flags.c_contiguous:
-            np_array = np.ascontiguousarray(np_array)
-    else:
-        # Ensure C-contiguous layout
-        if not np_array.flags.c_contiguous:
-            np_array = np.ascontiguousarray(np_array)
+    if not np_array.flags.c_contiguous:
+        raise ValueError("Input array must be C-contiguous")
 
-    # Infer infinicore dtype if not provided
-    infini_type = (
-        dtype if dtype is not None else numpy_to_infinicore_dtype(np_array.dtype)
-    )
-
-    # Default to CPU device if not provided
-    infini_device = device if device is not None else infinicore.device("cpu", 0)
+    infini_type = numpy_to_infinicore_dtype(np_array.dtype)
     cpu_device = infinicore.device("cpu", 0)
 
-    # Create a temporary tensor on CPU using from_blob to reference numpy array
-    # This allows us to copy data without keeping numpy array reference
+    # Create a infinicore.Tensor on CPU using from_blob to reference numpy array
     data_ptr = np_array.ctypes.data_as(ctypes.c_void_p).value
-    temp_tensor = Tensor(
+    infini_tensor = Tensor(
         _infinicore.from_blob(
             data_ptr,
             list(np_array.shape),
             dtype=infini_type._underlying,
             device=cpu_device._underlying,
-        )
+        ),
+        _numpy_ref=np_array,
     )
 
-    # Always create the result tensor on CPU first, then copy data
-    # This ensures we have a proper copy of the data
-    result = empty(list(np_array.shape), dtype=infini_type, device=cpu_device)
-    result.copy_(temp_tensor)
-
     # If target device is not CPU, move the tensor to the target device
-    # The temporary tensor and numpy array will be garbage collected
-    # since we don't keep references to them
-    if infini_device.type != "cpu":
-        result = result.to(infini_device)
+    if device is not None and device.type != "cpu":
+        infini_tensor = infini_tensor.to(device)
 
-    return result
+    return infini_tensor
 
 
 def from_list(data, *, dtype=None, device=None) -> Tensor:
@@ -329,4 +338,4 @@ def from_list(data, *, dtype=None, device=None) -> Tensor:
 
     # Reuse from_numpy to create the tensor
     # This avoids code duplication and ensures consistent behavior
-    return from_numpy(np_array, dtype=dtype, device=device)
+    return from_numpy(np_array, device=device)

--- a/python/infinicore/utils.py
+++ b/python/infinicore/utils.py
@@ -2,6 +2,12 @@ import ml_dtypes
 import numpy as np
 import torch
 
+try:
+    import torch
+except ImportError:
+    torch = None
+    print("warning: torch not available, some functions may not be available")
+
 import infinicore
 
 
@@ -94,4 +100,6 @@ def infinicore_to_numpy_dtype(infini_dtype):
     elif infini_dtype == infinicore.uint8:
         return np.uint8
     else:
-        raise ValueError(f"Unsupported infinicore dtype: {infini_dtype}")
+        raise ValueError(
+            f"Cannot convert infinicore dtype: {infini_dtype} to numpy dtype"
+        )


### PR DESCRIPTION
**目标版本**
main

**功能描述**
(1) 添加 infinicore.tensor函数，支持通过列表，numpy, 元组 ，scale  创建infinicore.Tensor
(2) 移除from_numpy函数的dtype参数

**测试结果**

**测试新增的infinicore.tensor函数**
<img width="965" height="1125" alt="Screenshot from 2026-01-13 14-28-10" src="https://github.com/user-attachments/assets/40304535-b6e6-4571-969f-d0a51372b1f8" />


**测试修改的from_numpy函数**
<img width="725" height="561" alt="Screenshot from 2026-01-07 17-57-10" src="https://github.com/user-attachments/assets/a9184872-9a33-455c-9247-bb30aaa78d07" />


修改后，InfiniLM的llama.py和jiuge.py测试通过

<img width="1438" height="485" alt="Screenshot from 2026-01-07 18-02-42" src="https://github.com/user-attachments/assets/4c1b34a3-9f78-49c4-8d87-773975d20f80" />
<img width="1623" height="620" alt="Screenshot from 2026-01-07 18-03-44" src="https://github.com/user-attachments/assets/78683b68-9a91-4414-96d9-6d99be829d9a" />
