### PR TITLE
issue/1042 - fix address misaligned error of rearrange

### DIFF
--- a/src/utils/rearrange.cc
+++ b/src/utils/rearrange.cc
@@ -144,11 +144,14 @@ void rearrange(
 utils::Result<RearrangeMeta> RearrangeMeta::distributeUnit(const std::vector<size_t> &candidates) const {
     // 获取当前的unit大小
     size_t current_unit = _meta[0];
+    const size_t ndim = this->ndim();
+    const ptrdiff_t dst_strides_0 = _meta[2 + ndim];
+    const ptrdiff_t src_strides_0 = _meta[2 + ndim + ndim];
 
     // 寻找满足条件的unit值：当前unit能被其整除
     size_t new_unit = 0;
-    for (size_t candidate : candidates) {
-        if (current_unit % candidate == 0) {
+    for (const size_t &candidate : candidates) {
+        if ((current_unit % candidate == 0) && 0 == (dst_strides_0 & (candidate - 1)) && 0 == (src_strides_0 & (candidate - 1))) {
             new_unit = candidate;
             break;
         }


### PR DESCRIPTION
`import infinicore

aa = infinicore.empty((4, 3), dtype=infinicore.int64, device=infinicore.device("cuda"))
bb = infinicore.empty((4, 2), dtype=infinicore.int64, device=infinicore.device("cuda"))
cc = aa.narrow(1, 0, 2)

print(aa.shape, aa.stride())
print(bb.shape, bb.stride())
print(cc.shape, cc.stride())

bb.copy_(cc)

infinicore.sync_stream()`

上述样例代码会报错。

**测试结果：**

**修改前**
<img width="1232" height="245" alt="Screenshot from 2026-03-02 20-01-11" src="https://github.com/user-attachments/assets/ca30b5ae-ed3e-4195-a3ca-9a7dde3bd6b5" />

**修改后**
<img width="1232" height="122" alt="Screenshot from 2026-03-02 20-01-57" src="https://github.com/user-attachments/assets/81345276-0e6a-4d12-8b7a-7bd567c99f3a" />


**算子单测**
<img width="1306" height="497" alt="Screenshot from 2026-03-04 14-20-25" src="https://github.com/user-attachments/assets/fe4ca529-7106-44b3-b7b7-236300958d3f" />


**服务推理结果**
cuda_graph的推理不再出错

<img width="1466" height="679" alt="Screenshot from 2026-03-02 21-20-59" src="https://github.com/user-attachments/assets/8de55777-2cb8-4ba8-a0bf-32cdb62e9cbd" />


<img width="1196" height="567" alt="Screenshot from 2026-03-04 16-43-08" src="https://github.com/user-attachments/assets/52e5d349-7394-43a6-9541-d6f669b5b9ab" />

<img width="1335" height="815" alt="Screenshot from 2026-03-04 16-59-49" src="https://github.com/user-attachments/assets/1bcab1d9-36c5-4d87-9811-559b9a9d2700" />
