### PR TITLE
issue/1092 - removed inappropriate argmax interface variations

### DIFF
--- a/src/infiniop/ops/random_sample/nvidia/random_sample_kernel.cuh
+++ b/src/infiniop/ops/random_sample/nvidia/random_sample_kernel.cuh
@@ -16,21 +16,10 @@ static cudaError argMax_(
     void *workspace_ptr,
     size_t &workspace_len,
     cudaStream_t stream) {
-#if CUDART_VERSION >= 11000 && !defined(ENABLE_QY_API) && !defined(ENABLE_HYGON_API)
-    // New interface: separate value and index outputs
-    T *max_value = &kv_pair->value;
-    int *max_index = &kv_pair->key;
-    return cub::DeviceReduce::ArgMax(
-        workspace_ptr, workspace_len,
-        logits, max_value, max_index, n,
-        stream);
-#else
-    // Old interface
     return cub::DeviceReduce::ArgMax(
         workspace_ptr, workspace_len,
         logits, kv_pair, n,
         stream);
-#endif
 }
 
 template <class Tval, class Tidx>


### PR DESCRIPTION
resolves #1092 

之前接flash attention库的时候这个地方出了问题，后来通过特判版本解决了。

后来多个平台这个地方编译都出了新问题，且原环境无法复现，考虑一并回退相关改动。

<img width="807" height="349" alt="image" src="https://github.com/user-attachments/assets/941e85ea-4236-4f21-9b53-6127c5d5c41d" />
