### PR TITLE
issue/1148: PagedAttentionPrefill 添加 KV cache 连续性 guard

### DIFF
--- a/python/infinicore/ops/paged_attention_prefill.py
+++ b/python/infinicore/ops/paged_attention_prefill.py
@@ -2,6 +2,12 @@ from infinicore.lib import _infinicore
 from infinicore.tensor import Tensor
 
 
+def _ensure_head_dim_contiguous(tensor: Tensor) -> Tensor:
+    if tensor.ndim > 0 and tensor.stride(tensor.ndim - 1) != 1:
+        return tensor.contiguous()
+    return tensor
+
+
 def paged_attention_prefill(
     q: Tensor,
     k_cache: Tensor,
@@ -14,6 +20,8 @@ def paged_attention_prefill(
     *,
     out: Tensor | None = None,
 ):
+    k_cache = _ensure_head_dim_contiguous(k_cache)
+    v_cache = _ensure_head_dim_contiguous(v_cache)
     alibi_ptr = alibi_slopes._underlying if alibi_slopes is not None else None
 
     if out is None:


### PR DESCRIPTION
## 关联 Issue

Closes #1148

## 改动内容

在 `python/infinicore/ops/paged_attention_prefill.py` 中添加 `_ensure_head_dim_contiguous` 辅助函数，对 `k_cache` 和 `v_cache` 的最后一维（head_dim）做连续性检查，不连续时自动调用 `.contiguous()`。

## 背景

`paged_attention_prefill` 底层算子按 head_dim 做点积运算，要求 KV cache 最后一维 stride 为 1，这是普遍要求而非特定后端问题。传入非连续张量会触发 `Bad Tensor Strides` 错误，导致测试 failed 56/60。

标准 vLLM KV cache view 的 head-dim stride 已经是 1，正常路径不会触发额外 copy。