### PR TITLE
feat: add Module::children() to expose direct submodules

### DIFF
--- a/include/infinicore/nn/module.hpp
+++ b/include/infinicore/nn/module.hpp
@@ -27,6 +27,10 @@ public:
 
     std::unordered_map<std::string, Module *> modules_dict() const;
 
+    const std::unordered_map<std::string, std::shared_ptr<Module>> &children() const {
+        return submodules_;
+    }
+
 protected:
     Tensor register_parameter(const std::string &name, Parameter param);
 

--- a/xmake/qy.lua
+++ b/xmake/qy.lua
@@ -7,7 +7,7 @@ local FLASH_ATTN_ROOT = get_config("flash-attn")
 
 local INFINI_ROOT = os.getenv("INFINI_ROOT") or (os.getenv(is_host("windows") and "HOMEPATH" or "HOME") .. "/.infini")
 
-function _qy_flash_attn_cuda_so_path()
+local function _qy_flash_attn_cuda_so_path()
     -- Highest priority: override the exact `.so` file to link.
     local env_path = os.getenv("FLASH_ATTN_2_CUDA_SO")
     if env_path and env_path ~= "" then


### PR DESCRIPTION
Add a public accessor for the direct submodule map so that recursive traversal (e.g. process_weights_after_loading) can iterate only immediate children instead of the fully flattened modules_dict().