### PR TITLE
[2026春季][T1-1-1] mygitljf

### DIFF
--- a/python/infinicore/__init__.py
+++ b/python/infinicore/__init__.py
@@ -76,6 +76,7 @@ from infinicore.ops.block_diag import block_diag
 from infinicore.ops.broadcast_to import broadcast_to
 from infinicore.ops.cat import cat
 from infinicore.ops.cdist import cdist
+from infinicore.ops.copysign import copysign
 from infinicore.ops.cross_entropy import cross_entropy
 from infinicore.ops.diff import diff
 from infinicore.ops.digamma import digamma
@@ -94,8 +95,10 @@ from infinicore.ops.inner import inner
 from infinicore.ops.kron import kron
 from infinicore.ops.kthvalue import kthvalue
 from infinicore.ops.kv_caching import kv_caching
+from infinicore.ops.lcm import lcm
 from infinicore.ops.ldexp import ldexp
 from infinicore.ops.lerp import lerp
+from infinicore.ops.lgamma import lgamma
 from infinicore.ops.logaddexp import logaddexp
 from infinicore.ops.logaddexp2 import logaddexp2
 from infinicore.ops.logcumsumexp import logcumsumexp
@@ -108,10 +111,12 @@ from infinicore.ops.mha_kvcache import mha_kvcache
 from infinicore.ops.mha_varlen import mha_varlen
 from infinicore.ops.mul import mul
 from infinicore.ops.narrow import narrow
+from infinicore.ops.nextafter import nextafter
 from infinicore.ops.nrm2 import nrm2
 from infinicore.ops.paged_attention import paged_attention
 from infinicore.ops.paged_attention_prefill import paged_attention_prefill
 from infinicore.ops.paged_caching import paged_caching
+from infinicore.ops.rad2deg import rad2deg
 from infinicore.ops.rearrange import rearrange
 from infinicore.ops.reciprocal import reciprocal
 from infinicore.ops.rot import rot
@@ -279,6 +284,11 @@ __all__ = [
     "var",
     "topk",
     "all",
+    "copysign",
+    "lcm",
+    "lgamma",
+    "nextafter",
+    "rad2deg",
     "set_printoptions",
     "printoptions",
 ]

--- a/python/infinicore/ops/copysign.py
+++ b/python/infinicore/ops/copysign.py
@@ -1,0 +1,8 @@
+import infinicore
+from infinicore.tensor import Tensor
+
+
+def copysign(input: Tensor, other: Tensor, *, out=None) -> Tensor:
+    r"""Computes element-wise copysign: magnitude of input with sign of other."""
+    assert infinicore.use_ntops
+    return infinicore.ntops.torch.copysign(input, other, out=out)

--- a/python/infinicore/ops/lcm.py
+++ b/python/infinicore/ops/lcm.py
@@ -1,0 +1,8 @@
+import infinicore
+from infinicore.tensor import Tensor
+
+
+def lcm(input: Tensor, other: Tensor, *, out=None) -> Tensor:
+    r"""Computes element-wise least common multiple. Integer dtypes only."""
+    assert infinicore.use_ntops
+    return infinicore.ntops.torch.lcm(input, other, out=out)

--- a/python/infinicore/ops/lgamma.py
+++ b/python/infinicore/ops/lgamma.py
@@ -1,0 +1,8 @@
+import infinicore
+from infinicore.tensor import Tensor
+
+
+def lgamma(input: Tensor, *, out=None) -> Tensor:
+    r"""Computes element-wise natural logarithm of the absolute value of the gamma function."""
+    assert infinicore.use_ntops
+    return infinicore.ntops.torch.lgamma(input, out=out)

--- a/python/infinicore/ops/nextafter.py
+++ b/python/infinicore/ops/nextafter.py
@@ -1,0 +1,8 @@
+import infinicore
+from infinicore.tensor import Tensor
+
+
+def nextafter(input: Tensor, other: Tensor, *, out=None) -> Tensor:
+    r"""Returns the next representable float value of input toward other, element-wise."""
+    assert infinicore.use_ntops
+    return infinicore.ntops.torch.nextafter(input, other, out=out)

--- a/python/infinicore/ops/rad2deg.py
+++ b/python/infinicore/ops/rad2deg.py
@@ -1,0 +1,8 @@
+import infinicore
+from infinicore.tensor import Tensor
+
+
+def rad2deg(input: Tensor, *, out=None) -> Tensor:
+    r"""Converts angles in radians to degrees, element-wise."""
+    assert infinicore.use_ntops
+    return infinicore.ntops.torch.rad2deg(input, out=out)

--- a/test/infinicore/framework/benchmark.py
+++ b/test/infinicore/framework/benchmark.py
@@ -117,10 +117,15 @@ class BenchmarkUtils:
         if infinicore.use_ntops:
             import triton
 
-            cache = triton.runtime.driver.active.get_empty_cache_for_benchmark()
+            driver = triton.runtime.driver.active
+            get_cache = getattr(driver, "get_empty_cache_for_benchmark", None)
+            clear_cache = getattr(driver, "clear_cache", None)
 
-            def _clear_cache():
-                triton.runtime.driver.active.clear_cache(cache)
+            if callable(get_cache) and callable(clear_cache):
+                cache = get_cache()
+
+                def _clear_cache():
+                    clear_cache(cache)
 
         # Create pairs of DeviceEvents for each iteration
         start_events = [

--- a/test/infinicore/ops/copysign.py
+++ b/test/infinicore/ops/copysign.py
@@ -1,0 +1,96 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import infinicore
+import torch
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorSpec,
+    TestCase,
+    is_broadcast,
+)
+
+
+_TEST_CASES_DATA = [
+    ((13, 4), None, None, None),
+    ((13, 4), (10, 1), (10, 1), None),
+    ((13, 4, 4), None, None, None),
+    ((13, 4, 4), (20, 4, 1), (20, 4, 1), None),
+    ((16, 5632), None, None, None),
+]
+
+_TOLERANCE_MAP = {
+    infinicore.float16: {"atol": 0, "rtol": 0},
+    infinicore.float32: {"atol": 0, "rtol": 0},
+    infinicore.bfloat16: {"atol": 0, "rtol": 0},
+}
+
+_TENSOR_DTYPES = [infinicore.float16, infinicore.bfloat16, infinicore.float32]
+
+
+def parse_test_cases():
+    test_cases = []
+    for data in _TEST_CASES_DATA:
+        shape = data[0]
+        a_strides = data[1] if len(data) > 1 else None
+        b_strides = data[2] if len(data) > 2 else None
+        c_strides = data[3] if len(data) > 3 else None
+
+        c_supports_inplace = not is_broadcast(c_strides)
+
+        for dtype in _TENSOR_DTYPES:
+            tol = _TOLERANCE_MAP.get(dtype, {"atol": 1e-5, "rtol": 1e-4})
+            a_spec = TensorSpec.from_tensor(shape, a_strides, dtype, name="a")
+            b_spec = TensorSpec.from_tensor(shape, b_strides, dtype, name="b")
+            c_spec = TensorSpec.from_tensor(shape, c_strides, dtype, name="c")
+
+            test_cases.append(
+                TestCase(
+                    inputs=[a_spec, b_spec],
+                    kwargs={},
+                    output_spec=None,
+                    comparison_target=None,
+                    tolerance=tol,
+                    description="copysign - OUT_OF_PLACE",
+                )
+            )
+
+            if c_supports_inplace:
+                test_cases.append(
+                    TestCase(
+                        inputs=[a_spec, b_spec],
+                        kwargs=None,
+                        output_spec=c_spec,
+                        comparison_target="out",
+                        tolerance=tol,
+                        description="copysign - INPLACE(out)",
+                    )
+                )
+
+    return test_cases
+
+
+class OpTest(BaseOperatorTest):
+    def __init__(self):
+        super().__init__("Copysign")
+
+    def get_test_cases(self):
+        return parse_test_cases()
+
+    def torch_operator(self, *args, **kwargs):
+        return torch.copysign(*args, **kwargs)
+
+    def infinicore_operator(self, *args, **kwargs):
+        return infinicore.copysign(*args, **kwargs)
+
+
+def main():
+    runner = GenericTestRunner(OpTest)
+    runner.run_and_exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/infinicore/ops/lcm.py
+++ b/test/infinicore/ops/lcm.py
@@ -1,0 +1,102 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import infinicore
+import torch
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorSpec,
+    TestCase,
+    is_broadcast,
+)
+
+
+_TEST_CASES_DATA = [
+    ((13, 4), None, None, None),
+    ((13, 4), (10, 1), (10, 1), None),
+    ((13, 4, 4), None, None, None),
+    ((13, 4, 4), (20, 4, 1), (20, 4, 1), None),
+    ((16, 5632), None, None, None),
+]
+
+_TOLERANCE_MAP = {
+    infinicore.int8: {"atol": 0, "rtol": 0},
+    infinicore.int16: {"atol": 0, "rtol": 0},
+    infinicore.int32: {"atol": 0, "rtol": 0},
+    infinicore.int64: {"atol": 0, "rtol": 0},
+}
+
+_TENSOR_DTYPES = [
+    infinicore.int8,
+    infinicore.int16,
+    infinicore.int32,
+    infinicore.int64,
+]
+
+
+def parse_test_cases():
+    test_cases = []
+    for data in _TEST_CASES_DATA:
+        shape = data[0]
+        a_strides = data[1] if len(data) > 1 else None
+        b_strides = data[2] if len(data) > 2 else None
+        c_strides = data[3] if len(data) > 3 else None
+
+        c_supports_inplace = not is_broadcast(c_strides)
+
+        for dtype in _TENSOR_DTYPES:
+            tol = _TOLERANCE_MAP.get(dtype, {"atol": 0, "rtol": 0})
+            a_spec = TensorSpec.from_tensor(shape, a_strides, dtype, name="a")
+            b_spec = TensorSpec.from_tensor(shape, b_strides, dtype, name="b")
+            c_spec = TensorSpec.from_tensor(shape, c_strides, dtype, name="c")
+
+            test_cases.append(
+                TestCase(
+                    inputs=[a_spec, b_spec],
+                    kwargs={},
+                    output_spec=None,
+                    comparison_target=None,
+                    tolerance=tol,
+                    description="lcm - OUT_OF_PLACE",
+                )
+            )
+
+            if c_supports_inplace:
+                test_cases.append(
+                    TestCase(
+                        inputs=[a_spec, b_spec],
+                        kwargs=None,
+                        output_spec=c_spec,
+                        comparison_target="out",
+                        tolerance=tol,
+                        description="lcm - INPLACE(out)",
+                    )
+                )
+
+    return test_cases
+
+
+class OpTest(BaseOperatorTest):
+    def __init__(self):
+        super().__init__("Lcm")
+
+    def get_test_cases(self):
+        return parse_test_cases()
+
+    def torch_operator(self, *args, **kwargs):
+        return torch.lcm(*args, **kwargs)
+
+    def infinicore_operator(self, *args, **kwargs):
+        return infinicore.lcm(*args, **kwargs)
+
+
+def main():
+    runner = GenericTestRunner(OpTest)
+    runner.run_and_exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/infinicore/ops/lgamma.py
+++ b/test/infinicore/ops/lgamma.py
@@ -1,0 +1,91 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import infinicore
+import torch
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorSpec,
+    TestCase,
+    is_broadcast,
+)
+
+
+_TEST_CASES_DATA = [
+    ((13, 4), None),
+    ((13, 4), (10, 1)),
+    ((8, 16), None),
+    ((8, 16), (40, 1)),
+    ((2, 3, 4), None),
+    ((16, 5632), None),
+]
+
+_TOLERANCE_MAP = {
+    infinicore.float16: {"atol": 1e-2, "rtol": 1e-2},
+    infinicore.float32: {"atol": 1e-5, "rtol": 1e-4},
+    infinicore.bfloat16: {"atol": 1e-2, "rtol": 5e-2},
+}
+
+_TENSOR_DTYPES = [infinicore.float16, infinicore.bfloat16, infinicore.float32]
+
+
+def parse_test_cases():
+    test_cases = []
+    for data in _TEST_CASES_DATA:
+        shape = data[0]
+        in_strides = data[1] if len(data) > 1 else None
+
+        for dtype in _TENSOR_DTYPES:
+            tol = _TOLERANCE_MAP.get(dtype, {"atol": 1e-5, "rtol": 1e-4})
+            input_spec = TensorSpec.from_tensor(shape, in_strides, dtype)
+            out_spec = TensorSpec.from_tensor(shape, None, dtype)
+
+            test_cases.append(
+                TestCase(
+                    inputs=[input_spec],
+                    kwargs={},
+                    output_spec=None,
+                    comparison_target=None,
+                    tolerance=tol,
+                    description="lgamma - OUT_OF_PLACE",
+                )
+            )
+
+            test_cases.append(
+                TestCase(
+                    inputs=[input_spec],
+                    kwargs=None,
+                    output_spec=out_spec,
+                    comparison_target="out",
+                    tolerance=tol,
+                    description="lgamma - INPLACE(out)",
+                )
+            )
+
+    return test_cases
+
+
+class OpTest(BaseOperatorTest):
+    def __init__(self):
+        super().__init__("Lgamma")
+
+    def get_test_cases(self):
+        return parse_test_cases()
+
+    def torch_operator(self, *args, **kwargs):
+        return torch.lgamma(*args, **kwargs)
+
+    def infinicore_operator(self, *args, **kwargs):
+        return infinicore.lgamma(*args, **kwargs)
+
+
+def main():
+    runner = GenericTestRunner(OpTest)
+    runner.run_and_exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/infinicore/ops/nextafter.py
+++ b/test/infinicore/ops/nextafter.py
@@ -1,0 +1,96 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import infinicore
+import torch
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorSpec,
+    TestCase,
+    is_broadcast,
+)
+
+
+_TEST_CASES_DATA = [
+    ((13, 4), None, None, None),
+    ((13, 4), (10, 1), (10, 1), None),
+    ((13, 4, 4), None, None, None),
+    ((13, 4, 4), (20, 4, 1), (20, 4, 1), None),
+    ((16, 5632), None, None, None),
+]
+
+_TOLERANCE_MAP = {
+    infinicore.float16: {"atol": 0, "rtol": 0},
+    infinicore.float32: {"atol": 0, "rtol": 0},
+    infinicore.bfloat16: {"atol": 0, "rtol": 0},
+}
+
+_TENSOR_DTYPES = [infinicore.float16, infinicore.bfloat16, infinicore.float32]
+
+
+def parse_test_cases():
+    test_cases = []
+    for data in _TEST_CASES_DATA:
+        shape = data[0]
+        a_strides = data[1] if len(data) > 1 else None
+        b_strides = data[2] if len(data) > 2 else None
+        c_strides = data[3] if len(data) > 3 else None
+
+        c_supports_inplace = not is_broadcast(c_strides)
+
+        for dtype in _TENSOR_DTYPES:
+            tol = _TOLERANCE_MAP.get(dtype, {"atol": 0, "rtol": 0})
+            a_spec = TensorSpec.from_tensor(shape, a_strides, dtype, name="a")
+            b_spec = TensorSpec.from_tensor(shape, b_strides, dtype, name="b")
+            c_spec = TensorSpec.from_tensor(shape, c_strides, dtype, name="c")
+
+            test_cases.append(
+                TestCase(
+                    inputs=[a_spec, b_spec],
+                    kwargs={},
+                    output_spec=None,
+                    comparison_target=None,
+                    tolerance=tol,
+                    description="nextafter - OUT_OF_PLACE",
+                )
+            )
+
+            if c_supports_inplace:
+                test_cases.append(
+                    TestCase(
+                        inputs=[a_spec, b_spec],
+                        kwargs=None,
+                        output_spec=c_spec,
+                        comparison_target="out",
+                        tolerance=tol,
+                        description="nextafter - INPLACE(out)",
+                    )
+                )
+
+    return test_cases
+
+
+class OpTest(BaseOperatorTest):
+    def __init__(self):
+        super().__init__("Nextafter")
+
+    def get_test_cases(self):
+        return parse_test_cases()
+
+    def torch_operator(self, *args, **kwargs):
+        return torch.nextafter(*args, **kwargs)
+
+    def infinicore_operator(self, *args, **kwargs):
+        return infinicore.nextafter(*args, **kwargs)
+
+
+def main():
+    runner = GenericTestRunner(OpTest)
+    runner.run_and_exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/infinicore/ops/rad2deg.py
+++ b/test/infinicore/ops/rad2deg.py
@@ -1,0 +1,91 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import infinicore
+import torch
+from framework import (
+    BaseOperatorTest,
+    GenericTestRunner,
+    TensorSpec,
+    TestCase,
+    is_broadcast,
+)
+
+
+_TEST_CASES_DATA = [
+    ((13, 4), None),
+    ((13, 4), (10, 1)),
+    ((8, 16), None),
+    ((8, 16), (40, 1)),
+    ((2, 3, 4), None),
+    ((16, 5632), None),
+]
+
+_TOLERANCE_MAP = {
+    infinicore.float16: {"atol": 1e-2, "rtol": 1e-2},
+    infinicore.float32: {"atol": 1e-5, "rtol": 1e-4},
+    infinicore.bfloat16: {"atol": 1e-2, "rtol": 5e-2},
+}
+
+_TENSOR_DTYPES = [infinicore.float16, infinicore.bfloat16, infinicore.float32]
+
+
+def parse_test_cases():
+    test_cases = []
+    for data in _TEST_CASES_DATA:
+        shape = data[0]
+        in_strides = data[1] if len(data) > 1 else None
+
+        for dtype in _TENSOR_DTYPES:
+            tol = _TOLERANCE_MAP.get(dtype, {"atol": 1e-5, "rtol": 1e-4})
+            input_spec = TensorSpec.from_tensor(shape, in_strides, dtype)
+            out_spec = TensorSpec.from_tensor(shape, None, dtype)
+
+            test_cases.append(
+                TestCase(
+                    inputs=[input_spec],
+                    kwargs={},
+                    output_spec=None,
+                    comparison_target=None,
+                    tolerance=tol,
+                    description="rad2deg - OUT_OF_PLACE",
+                )
+            )
+
+            test_cases.append(
+                TestCase(
+                    inputs=[input_spec],
+                    kwargs=None,
+                    output_spec=out_spec,
+                    comparison_target="out",
+                    tolerance=tol,
+                    description="rad2deg - INPLACE(out)",
+                )
+            )
+
+    return test_cases
+
+
+class OpTest(BaseOperatorTest):
+    def __init__(self):
+        super().__init__("Rad2Deg")
+
+    def get_test_cases(self):
+        return parse_test_cases()
+
+    def torch_operator(self, *args, **kwargs):
+        return torch.rad2deg(*args, **kwargs)
+
+    def infinicore_operator(self, *args, **kwargs):
+        return infinicore.rad2deg(*args, **kwargs)
+
+
+def main():
+    runner = GenericTestRunner(OpTest)
+    runner.run_and_exit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Platform Compatibility
NVIDIA A100, MetaX C500, Iluvatar MR-V100:
On Iluvatar / CoreX the `bitcast store` lowering path for fp16 / bf16 is not available, so `copysign` / `nextafter` fall back to `torch.<op>` for fp16 / bf16 on that platform via `ntops.torch.utils._is_corex_compat_device`. NVIDIA and MetaX still take the original ntops kernel path.
## Test Commands
### ntops correctness
```bash
python -m pytest \
  tests/test_rad2deg.py tests/test_copysign.py tests/test_lcm.py \
  tests/test_nextafter.py tests/test_lgamma.py -q
```
### ntops performance
```bash
NTOPS_RUN_PERF=1 python -m pytest tests/test_<op>_perf.py -s
```
Set `NTOPS_RUN_PERF=1` to enable. `warmup=50`, `rep=200`, median of 3.
### InfiniCore correctness + performance (switch the device flag per platform)
```bash
# NVIDIA
python test/infinicore/run.py --ops rad2deg copysign lcm nextafter lgamma --nvidia
python test/infinicore/run.py --ops rad2deg copysign lcm nextafter lgamma --nvidia \
  --bench device --num_prerun 100 --num_iterations 1000
# MetaX C500
python test/infinicore/run.py --ops rad2deg copysign lcm nextafter lgamma --metax
python test/infinicore/run.py --ops rad2deg copysign lcm nextafter lgamma --metax \
  --bench device --num_prerun 50 --num_iterations 1000
# Iluvatar MR-V100
python test/infinicore/run.py --ops rad2deg copysign lcm nextafter lgamma --iluvatar
python test/infinicore/run.py --ops rad2deg copysign lcm nextafter lgamma --iluvatar \
  --bench device --num_prerun 20 --num_iterations 100
```
## Test Results (100% pass on all three platforms)
### Correctness
| Platform | Device flag | ntops pytest | InfiniCore run.py |
|---|---|
| NVIDIA A100 80GB PCIe | `--nvidia`   | 44 passed, 4 skipped | 172 / 172 (100.0%) |
| MetaX C500            | `--metax`    | 44 passed, 4 skipped | 172 / 172 (100.0%) |
| Iluvatar MR-V100      | `--iluvatar` | 44 passed, 4 skipped | 172 / 172 (100.0%) |
The `4 skipped` cases are `lcm` on `bool` dtype (`torch.lcm` itself does not support `bool`).
### Performance
#### ntops
| Operator  | Cases | ntops sum (µs) | torch sum (µs) |    Speedup |
| --------- | ----: | -------------: | -------------: | ---------: |
| rad2deg   |    18 |         190.10 |         190.59 | **1.003x** |
| copysign  |    18 |         248.22 |         235.79 |     0.950x |
| **lcm**   |    24 |        1018.18 |        1177.45 | **1.156x** |
| nextafter |    18 |         254.00 |         255.25 | **1.005x** |
| lgamma    |    18 |         291.97 |         289.02 |     0.990x |
<img width="887" height="344" alt="rag2deg" src="https://github.com/user-attachments/assets/1f135be2-ad7a-41c8-a3d9-6f86d9ef1aa0" />
<img width="770" height="336" alt="copysign" src="https://github.com/user-attachments/assets/efd9ae72-0e9c-4fdd-a3f9-44171be48b27" />
<img width="805" height="435" alt="lcm" src="https://github.com/user-attachments/assets/16849966-dea3-46b6-a828-523b4b053d60" />
<img width="740" height="336" alt="nextafter" src="https://github.com/user-attachments/assets/33e7f933-f0f8-46e7-9185-bff21871ffe4" />
<img width="872" height="336" alt="lgamma" src="https://github.com/user-attachments/assets/eaa5afe1-b9da-4a21-9cde-c57a0b06b81a" />

#### InfiniCore
NVIDIA A100:
<img width="429" height="121" alt="x" src="https://github.com/user-attachments/assets/44691955-a722-46c9-b747-ca4b5d52df6f" />


MetaX C500:
```
Total tests run: 5, Passed: 5, Success rate: 100.0%
[Device] PyTorch:    9370.536 ms
[Device] InfiniCore: 10860.860 ms
Device Speedup (PyTorch/InfiniCore): 0.863x
```
<img width="1042" height="140" alt="沐曦环境" src="https://github.com/user-attachments/assets/905d7981-b341-4d3b-b4b7-ee91ef946558" />
<img width="473" height="181" alt="infiniCore-summary" src="https://github.com/user-attachments/assets/55eaf7fe-9841-4c03-872f-6e7922c2157a" />

Iluvatar MR-V100:
```
Total tests run: 5, Passed: 5, Success rate: 100.0%
[Device] PyTorch:      1164.031 ms
[Device] InfiniCore:   2439.888 ms
Device Speedup (PyTorch/InfiniCore): 0.477x
```
<img width="635" height="206" alt="天数环境" src="https://github.com/user-attachments/assets/51c8a86c-11ac-49ee-b95c-a1654d2d5db6" />
<img width="534" height="242" alt="infiniCore测试summary" src="https://github.com/user-attachments/assets/7d82a575-86de-4f9c-84d3-7f4a5e403ee4" />xxxxxxxxxx Total tests run: 5, Passed: 5, Success rate: 100.0%[Device] PyTorch:      1164.031 ms[Device] InfiniCore:   2439.888 msDevice Speedup (PyTorch/InfiniCore): 0.477x