### PR TITLE
issue/1194: add InfiniCCL as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 	path = third_party/nlohmann_json
 	url = https://github.com/nlohmann/json.git
 	branch = master
+[submodule "submodules/InfiniCCL"]
+	path = submodules/InfiniCCL
+	url = https://github.com/InfiniTensor/InfiniCCL.git
+	branch = master


### PR DESCRIPTION
## Summary

This PR adds InfiniCCL as a git submodule under the root-level `submodules/` directory:

```text
submodules/InfiniCCL
```

The submodule points to:

```text
https://github.com/InfiniTensor/InfiniCCL.git
branch: master
commit: c21a5b465dbdd94bdc246e32cf9c985f2ca01c9e
```

The submodule commit was verified to match the current remote `master` HEAD of InfiniCCL.

## Changes

* Added `.gitmodules` entry for `submodules/InfiniCCL`
* Added `submodules/InfiniCCL` gitlink
* No InfiniCore source code, build script, or test file changes

## Verification

### Submodule integration

Verified that:

* `submodules/InfiniCCL` exists
* `src/InfiniCCL` does not exist
* `git submodule update --init --recursive --remote ` can fetch the submodule
* `submodules/InfiniCCL` is checked out at `c21a5b465dbdd94bdc246e32cf9c985f2ca01c9e`
* The submodule commit matches InfiniCCL remote `master`

### InfiniCore environment deployment

Commands:

```bash
source scripts/set_env_linux.sh
python scripts/install.py --nv-gpu=y --cuda=$CUDA_HOME
xmake build _infinicore
xmake install _infinicore
pip install .
python -c "import infinicore; print('IMPORT_OK')"
```

Result:

```text
IMPORT_OK
```

Conclusion: PASS. InfiniCore can be built, installed, and imported successfully.

### InfiniCore single-operator auto evaluation

Command:

```bash
python test/infinicore/ops/add.py --nvidia
```

Result:

```text
Total tests: 102
Passed: 102
Success rate: 100.0%
All tests passed
```

Conclusion: PASS.

### InfiniCore batch-operator auto evaluation

Command:

```bash
python test/infinicore/run.py --nvidia --ops add mul rms_norm
```

Result:

```text
Targeted operators: add, rms_norm, mul
Tests found: 3

rms_norm: PASSED
mul: PASSED
add: PASSED

CUMULATIVE TEST SUMMARY
Total tests run: 3
Passed: 3
Failed: 0
Success rate: 100.0%
All tests passed
```

Conclusion: PASS. The three targeted InfiniCore operator test scripts completed sequentially and generated a cumulative summary.

## Additional note

An additional full-suite run with:

```bash
python test/infinicore/run.py --nvidia
```

was attempted separately. In the full local repository, this command discovers all operator test scripts. The run did not complete because an existing InfiniCore operator test, `index_copy`, triggered a segmentation fault. This is not related to the InfiniCCL submodule integration, because this PR only adds `submodules/InfiniCCL` as a submodule and does not compile or link InfiniCCL into InfiniCore.

## Related Issue

Closes #1194
