### PR TITLE
issue/1194: add InfiniOps as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 	path = third_party/nlohmann_json
 	url = https://github.com/nlohmann/json.git
 	branch = master
+[submodule "submodules/InfiniOps"]
+	path = submodules/InfiniOps
+	url = https://github.com/InfiniTensor/InfiniOps.git
+	branch = master


### PR DESCRIPTION
## Summary

This PR adds InfiniOps as a git submodule under the root-level `submodules/` directory:

```text
submodules/InfiniOps
```

The submodule points to:

```text
https://github.com/InfiniTensor/InfiniOps.git
branch: master
commit: 316ad6b0734b67a7c82362a86154a3301d0d6ea2
```

## Changes

- Added `.gitmodules` entry for `submodules/InfiniOps`
- Added `submodules/InfiniOps` gitlink
- No source code, build script, or test file changes

## Verification

Verified on `nvidia` that:

- `.gitmodules` contains the expected `path`, `url`, and `branch`
- `git submodule status submodules/InfiniOps` reports `316ad6b0734b67a7c82362a86154a3301d0d6ea2`
- The staged diff only contains `.gitmodules` and `submodules/InfiniOps` gitlink