### PR TITLE
issue/1235 - implement and optimize conv2d packaging

### DIFF
--- a/python/infinicore/__init__.py
+++ b/python/infinicore/__init__.py
@@ -76,6 +76,7 @@ from infinicore.ops.block_diag import block_diag
 from infinicore.ops.broadcast_to import broadcast_to
 from infinicore.ops.cat import cat
 from infinicore.ops.cdist import cdist
+from infinicore.ops.conv2d import conv2d
 from infinicore.ops.cross_entropy import cross_entropy
 from infinicore.ops.diff import diff
 from infinicore.ops.digamma import digamma
@@ -219,6 +220,7 @@ __all__ = [
     "bilinear",
     "fmod",
     "cat",
+    "conv2d",
     "inner",
     "masked_select",
     "logaddexp",

--- a/python/infinicore/nn/functional/__init__.py
+++ b/python/infinicore/nn/functional/__init__.py
@@ -1,3 +1,5 @@
+from infinicore.ops.conv2d import conv2d
+
 from .adaptive_avg_pool1d import adaptive_avg_pool1d
 from .adaptive_avg_pool3d import adaptive_avg_pool3d
 from .adaptive_max_pool1d import adaptive_max_pool1d
@@ -39,6 +41,7 @@ from .unfold import unfold
 from .upsample_bilinear import upsample_bilinear
 
 __all__ = [
+    "conv2d",
     "adaptive_max_pool1d",
     "causal_softmax",
     "embedding",

--- a/python/infinicore/ops/conv2d.py
+++ b/python/infinicore/ops/conv2d.py
@@ -1,0 +1,47 @@
+from infinicore.lib import _infinicore
+from infinicore.tensor import Tensor, zeros
+
+
+def _pair(value):
+    if isinstance(value, int):
+        return [value, value]
+    return list(value)
+
+
+def conv2d(
+    input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1, *, out=None
+):
+    if groups != 1:
+        raise NotImplementedError(
+            "infinicore.ops.conv2d currently supports groups=1 only"
+        )
+
+    stride = _pair(stride)
+    padding = _pair(padding)
+    dilation = _pair(dilation)
+    if bias is None:
+        bias = zeros((weight.shape[0],), dtype=weight.dtype, device=weight.device)
+    bias_raw = bias._underlying
+
+    if out is None:
+        return Tensor(
+            _infinicore.conv2d(
+                input._underlying,
+                weight._underlying,
+                bias_raw,
+                padding,
+                stride,
+                dilation,
+            )
+        )
+
+    _infinicore.conv2d_(
+        out._underlying,
+        input._underlying,
+        weight._underlying,
+        bias_raw,
+        padding,
+        stride,
+        dilation,
+    )
+    return out

--- a/src/infinicore/ops/conv2d/conv2d.cc
+++ b/src/infinicore/ops/conv2d/conv2d.cc
@@ -19,7 +19,10 @@ void Conv2d::execute(Tensor output,
                      const size_t *strides,
                      const size_t *dilations,
                      size_t n) {
-    INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input, weight, bias);
+    INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input, weight);
+    if (bias) {
+        INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, bias);
+    }
     infinicore::context::setDevice(output->device());
     auto device_type = output->device().getType();
     auto func = dispatcher().lookup(device_type);

--- a/src/infinicore/pybind11/ops.hpp
+++ b/src/infinicore/pybind11/ops.hpp
@@ -34,6 +34,7 @@
 #include "ops/cat.hpp"
 #include "ops/causal_softmax.hpp"
 #include "ops/cdist.hpp"
+#include "ops/conv2d.hpp"
 #include "ops/cross_entropy.hpp"
 #include "ops/diff.hpp"
 #include "ops/digamma.hpp"
@@ -189,6 +190,7 @@ inline void bind(py::module &m) {
     bind_prelu(m);
     bind_random_sample(m);
     bind_cross_entropy(m);
+    bind_conv2d(m);
     bind_hypot(m);
     bind_take(m);
     bind_index_copy(m);

--- a/src/infinicore/pybind11/ops/conv2d.hpp
+++ b/src/infinicore/pybind11/ops/conv2d.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "infinicore/ops/conv2d.hpp"
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace infinicore::ops {
+
+Tensor py_conv2d(Tensor input,
+                 Tensor weight,
+                 pybind11::object bias,
+                 const std::vector<size_t> &padding,
+                 const std::vector<size_t> &stride,
+                 const std::vector<size_t> &dilation) {
+    Tensor bias_tensor;
+    if (!bias.is_none()) {
+        bias_tensor = bias.cast<Tensor>();
+    }
+    return op::conv2d(input, weight, bias_tensor, padding, stride, dilation);
+}
+
+void py_conv2d_(Tensor out,
+                Tensor input,
+                Tensor weight,
+                pybind11::object bias,
+                const std::vector<size_t> &padding,
+                const std::vector<size_t> &stride,
+                const std::vector<size_t> &dilation) {
+    Tensor bias_tensor;
+    if (!bias.is_none()) {
+        bias_tensor = bias.cast<Tensor>();
+    }
+    op::conv2d_(out, input, weight, bias_tensor, padding, stride, dilation);
+}
+
+inline void bind_conv2d(py::module &m) {
+    m.def("conv2d",
+          &ops::py_conv2d,
+          py::arg("input"),
+          py::arg("weight"),
+          py::arg("bias") = py::none(),
+          py::arg("padding") = std::vector<size_t>{0, 0},
+          py::arg("stride") = std::vector<size_t>{1, 1},
+          py::arg("dilation") = std::vector<size_t>{1, 1},
+          R"doc(Applies a 2D convolution over an input tensor.)doc");
+
+    m.def("conv2d_",
+          &ops::py_conv2d_,
+          py::arg("out"),
+          py::arg("input"),
+          py::arg("weight"),
+          py::arg("bias") = py::none(),
+          py::arg("padding") = std::vector<size_t>{0, 0},
+          py::arg("stride") = std::vector<size_t>{1, 1},
+          py::arg("dilation") = std::vector<size_t>{1, 1},
+          R"doc(In-place 2D convolution.)doc");
+}
+
+} // namespace infinicore::ops

--- a/test/infinicore/ops/conv2d.py
+++ b/test/infinicore/ops/conv2d.py
@@ -89,9 +89,8 @@ class OpTest(BaseOperatorTest):
     def torch_operator(self, *args, **kwargs):
         return torch.nn.functional.conv2d(*args, **kwargs)
 
-    # def infinicore_operator(self, *args, **kwargs):
-    #     """InfiniCore implementation (operator not yet available)."""
-    #     return infinicore.nn.functional.conv2d(*args, **kwargs)
+    def infinicore_operator(self, *args, **kwargs):
+        return infinicore.nn.functional.conv2d(*args, **kwargs)
 
 
 def main():


### PR DESCRIPTION
closes #1235 

补全并优化conv的外层封装，

原来这里直接检查：
`INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input, weight, bias);`
但 bias 可以是空 Tensor。当 Python 侧或 C++ 侧传无 bias 卷积时，这个宏会把空 bias 也当成有效 tensor 去访问，导致崩溃风险。
所以改成：
```
INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input, weight);
if (bias) {
    INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, bias);
}
```
也就是：output/input/weight 必须同设备；只有 bias 存在时才检查 bias。
虽然 Python wrapper 里后来为了底层 infiniop 路径稳定，已经在 bias is None 时补了零 bias，但 C++ 上层 conv2d 本身也应该正确处理可选 bias。这个改动就是把这个语义补完整。

<img width="1100" height="847" alt="image" src="https://github.com/user-attachments/assets/be3bcd37-20b8-458c-afbd-dc748ce3fb52" />

先前本测试不可用