### PR TITLE
Issue/1292: Add reusable workspace support for Marlin GEMM

### DIFF
--- a/include/infinicore/context/context.hpp
+++ b/include/infinicore/context/context.hpp
@@ -22,6 +22,7 @@ infiniopHandle_t getInfiniopHandle(Device device);
 
 void syncStream();
 void syncDevice();
+void trimMemory();
 
 std::shared_ptr<Memory> allocateMemory(size_t size);
 std::shared_ptr<Memory> allocateHostMemory(size_t size);

--- a/include/infinicore/nn/linear.hpp
+++ b/include/infinicore/nn/linear.hpp
@@ -39,7 +39,7 @@ public:
     Tensor gidx() const { return gidx_; }
 
     std::shared_ptr<infinicore::quantization::BaseQuantization> get_quantization() const { return quantization_; }
-    void process_weights_after_loading();
+    void process_weights_after_loading() override;
 
 protected:
     // Parameters

--- a/include/infinicore/nn/module.hpp
+++ b/include/infinicore/nn/module.hpp
@@ -18,6 +18,8 @@ public:
 
     std::unordered_map<std::string, Parameter> state_dict() const;
 
+    std::vector<std::string> state_dict_keys() const;
+
     void load_state_dict(const std::unordered_map<std::string, Tensor> &_state_dict);
 
     void load_parameter(const std::string &name, const Tensor &param);
@@ -94,6 +96,7 @@ protected:
 private:
     void load_state_dict_recursively(const std::unordered_map<std::string, Tensor> &_state_dict, const std::string &prefix = "");
     void collect_all_parameters(std::unordered_map<std::string, Parameter> &all_params, const std::string &prefix = "") const;
+    void collect_all_parameter_names(std::vector<std::string> &all_names, const std::string &prefix = "") const;
     void collect_all_modules(std::unordered_map<std::string, Module *> &out, const std::string &prefix) const;
 };
 

--- a/include/infinicore/nn/module.hpp
+++ b/include/infinicore/nn/module.hpp
@@ -32,6 +32,10 @@ public:
 
     std::unordered_map<std::string, Module *> modules_dict() const;
 
+    virtual void process_weights_after_loading() {}
+
+    virtual void reset_runtime_state() const {}
+
     const std::unordered_map<std::string, std::shared_ptr<Module>> &children() const {
         return submodules_;
     }

--- a/include/infinicore/ops/gptq_marlin_gemm.hpp
+++ b/include/infinicore/ops/gptq_marlin_gemm.hpp
@@ -8,7 +8,11 @@
 namespace infinicore::op {
 
 INFINICORE_GRAPH_OP_CLASS(GptqMarlinGemm, Tensor, const Tensor &, const Tensor &, Tensor &, Tensor &, Tensor &, Tensor &, Tensor &, int64_t, bool, bool, bool, bool);
+INFINICORE_GRAPH_OP_CLASS(GptqMarlinGemmWithWorkspace, Tensor, Tensor, const Tensor &, const Tensor &, Tensor &, Tensor &, Tensor &, Tensor &, Tensor &, int64_t, bool, bool, bool, bool);
 
 void gptq_marlin_gemm_(Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float);
 
+size_t gptq_marlin_gemm_workspace_size(Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm);
+void gptq_marlin_gemm_with_workspace_(Tensor workspace, Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float);
+void gptq_marlin_gemm_with_workspace_direct_(Tensor workspace, Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float);
 } // namespace infinicore::op

--- a/src/infinicore/context/context_impl.cc
+++ b/src/infinicore/context/context_impl.cc
@@ -117,6 +117,10 @@ void syncDevice() {
     return ContextImpl::singleton().getCurrentRuntime()->syncDevice();
 }
 
+void trimMemory() {
+    return ContextImpl::singleton().getCurrentRuntime()->trimMemory();
+}
+
 std::shared_ptr<Memory> allocateMemory(size_t size) {
     return ContextImpl::singleton().getCurrentRuntime()->allocateMemory(size);
 }

--- a/src/infinicore/context/runtime/runtime.cc
+++ b/src/infinicore/context/runtime/runtime.cc
@@ -54,6 +54,10 @@ void Runtime::syncDevice() {
     INFINICORE_CHECK_ERROR(infinirtDeviceSynchronize());
 }
 
+void Runtime::trimMemory() {
+    device_memory_allocator_->trim();
+}
+
 std::shared_ptr<Memory> Runtime::allocateMemory(size_t size) {
     std::byte *data_ptr = device_memory_allocator_->allocate(size);
     return std::make_shared<Memory>(

--- a/src/infinicore/context/runtime/runtime.hpp
+++ b/src/infinicore/context/runtime/runtime.hpp
@@ -34,6 +34,7 @@ public:
 
     void syncStream();
     void syncDevice();
+    void trimMemory();
 
     std::shared_ptr<Memory> allocateMemory(size_t size);
     std::shared_ptr<Memory> allocatePinnedHostMemory(size_t size);

--- a/src/infinicore/nn/module.cc
+++ b/src/infinicore/nn/module.cc
@@ -21,18 +21,51 @@ std::unordered_map<std::string, Parameter> Module::state_dict() const {
     return result;
 }
 
+std::vector<std::string> Module::state_dict_keys() const {
+    std::vector<std::string> result;
+    collect_all_parameter_names(result, "");
+    return result;
+}
+
 void Module::load_state_dict(const std::unordered_map<std::string, Tensor> &_state_dict) {
     load_state_dict_recursively(_state_dict, "");
 }
 
 void Module::load_parameter(const std::string &name, const Tensor &param) {
-    auto all_params = state_dict();
-    auto existing_param = get_state_dict_parameter(all_params, name);
-    try {
-        existing_param.load(param);
-    } catch (const std::exception &e) {
-        throw std::runtime_error("Error loading parameter '" + name + "'. \n" + e.what());
+    auto param_it = parameters_.find(name);
+    if (param_it != parameters_.end()) {
+        try {
+            param_it->second.load(param);
+        } catch (const std::exception &e) {
+            throw std::runtime_error("Error loading parameter '" + name + "'. \n" + e.what());
+        }
+        return;
     }
+
+    std::shared_ptr<Module> matched_submodule;
+    std::string matched_prefix;
+    for (const auto &[sub_name, submodule] : submodules_) {
+        if (name.size() <= sub_name.size() || name.compare(0, sub_name.size(), sub_name) != 0 || name[sub_name.size()] != '.') {
+            continue;
+        }
+        if (sub_name.size() > matched_prefix.size()) {
+            matched_prefix = sub_name;
+            matched_submodule = submodule;
+        }
+    }
+
+    if (matched_submodule) {
+        try {
+            matched_submodule->load_parameter(name.substr(matched_prefix.size() + 1), param);
+        } catch (const std::exception &e) {
+            throw std::runtime_error("Error loading parameter '" + name + "'. \n" + e.what());
+        }
+        return;
+    }
+
+    spdlog::debug("load_parameter: Parameter '{}' not found. Available direct params={}, submodules={}",
+                  name, parameters_.size(), submodules_.size());
+    throw std::runtime_error("Parameter '" + name + "' not found in module.");
 }
 
 void Module::load_parameters_no_sync(const std::unordered_map<std::string, Tensor> &params) {
@@ -109,6 +142,17 @@ void Module::collect_all_parameters(std::unordered_map<std::string, Parameter> &
     for (const auto &[sub_name, submodule] : submodules_) {
         std::string sub_prefix = prefix.empty() ? sub_name : prefix + "." + sub_name;
         submodule->collect_all_parameters(all_params, sub_prefix);
+    }
+}
+
+void Module::collect_all_parameter_names(std::vector<std::string> &all_names, const std::string &prefix) const {
+    for (const auto &[param_name, _] : parameters_) {
+        all_names.push_back(prefix.empty() ? param_name : prefix + "." + param_name);
+    }
+
+    for (const auto &[sub_name, submodule] : submodules_) {
+        std::string sub_prefix = prefix.empty() ? sub_name : prefix + "." + sub_name;
+        submodule->collect_all_parameter_names(all_names, sub_prefix);
     }
 }
 

--- a/src/infinicore/ops/awq_marlin_gemm/awq_marlin_gemm_infiniop.cc
+++ b/src/infinicore/ops/awq_marlin_gemm/awq_marlin_gemm_infiniop.cc
@@ -25,7 +25,9 @@ void *plan(Tensor c, const Tensor &a, const Tensor &b, Tensor &b_bias, Tensor &b
         c->desc(), a->desc(),
         b->desc(), b_bias->desc(), b_scales->desc(), a_scales->desc(), global_scales->desc(), b_zeros->desc(), g_idx->desc(), perm->desc());
 
-    INFINIOP_WORKSPACE_TENSOR(workspace, AwqMarlinGemm, descriptor);
+    size_t workspace_size = 0;
+    INFINICORE_CHECK_ERROR(infiniopGetAwqMarlinGemmWorkspaceSize(descriptor->desc, &workspace_size));
+    Tensor workspace = Tensor::zeros({workspace_size}, DataType::U8, context::getDevice());
 
     return new PlannedMeta{
         descriptor,

--- a/src/infinicore/ops/awq_marlin_gemm/awq_marlin_gemm_infiniop.cc
+++ b/src/infinicore/ops/awq_marlin_gemm/awq_marlin_gemm_infiniop.cc
@@ -49,6 +49,9 @@ void *plan(Tensor c, const Tensor &a, const Tensor &b, Tensor &b_bias, Tensor &b
 
 void run(void *planned_meta) {
     auto planned = reinterpret_cast<PlannedMeta *>(planned_meta);
+    auto optional_data = [](graph::GraphTensor &tensor) -> void * {
+        return tensor->numel() == 0 ? nullptr : tensor->data();
+    };
 
     INFINICORE_CHECK_ERROR(infiniopAwqMarlinGemm(
         planned->descriptor->desc,
@@ -57,13 +60,13 @@ void run(void *planned_meta) {
         planned->c->data(),
         planned->a->data(),
         planned->b->data(),
-        planned->b_bias->data(),
+        optional_data(planned->b_bias),
         planned->b_scales->data(),
-        planned->a_scales->data(),
-        planned->global_scales->data(),
-        planned->b_zeros->data(),
-        planned->g_idx->data(),
-        planned->perm->data(),
+        optional_data(planned->a_scales),
+        optional_data(planned->global_scales),
+        optional_data(planned->b_zeros),
+        optional_data(planned->g_idx),
+        optional_data(planned->perm),
         planned->b_q_type_id,
         planned->is_k_full,
         planned->use_atomic_add,

--- a/src/infinicore/ops/gptq_marlin_gemm/gptq_marlin_gemm.cc
+++ b/src/infinicore/ops/gptq_marlin_gemm/gptq_marlin_gemm.cc
@@ -1,10 +1,12 @@
 #include "infinicore/ops/gptq_marlin_gemm.hpp"
 
 #include "../../utils.hpp"
+#include "infinicore/context/context.hpp"
 
 namespace infinicore::op {
 
 INFINICORE_GRAPH_OP_DISPATCHERS_IMPL(GptqMarlinGemm);
+INFINICORE_GRAPH_OP_DISPATCHERS_IMPL(GptqMarlinGemmWithWorkspace);
 
 GptqMarlinGemm::GptqMarlinGemm(Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float) {
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(out, a, b, b_scales, global_scales, b_zeros, g_idx, perm);
@@ -16,6 +18,23 @@ void GptqMarlinGemm::execute(Tensor out, const Tensor &a, const Tensor &b, Tenso
 
 void gptq_marlin_gemm_(Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float) {
     GptqMarlinGemm::execute(out, a, b, b_scales, global_scales, b_zeros, g_idx, perm, b_q_type_id, is_k_full, use_atomic_add, use_fp32_reduce, is_zp_float);
+}
+
+GptqMarlinGemmWithWorkspace::GptqMarlinGemmWithWorkspace(Tensor workspace, Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float) {
+    INFINICORE_ASSERT_TENSORS_SAME_DEVICE(workspace, out, a, b, b_scales, global_scales, b_zeros, g_idx, perm);
+    INFINICORE_GRAPH_OP_DISPATCH(out->device().getType(), workspace, out, a, b, b_scales, global_scales, b_zeros, g_idx, perm, b_q_type_id, is_k_full, use_atomic_add, use_fp32_reduce, is_zp_float);
+}
+
+void GptqMarlinGemmWithWorkspace::execute(Tensor workspace, Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float) {
+    INFINICORE_GRAPH_OP_RECORD_OR_RUN(GptqMarlinGemmWithWorkspace, workspace, out, a, b, b_scales, global_scales, b_zeros, g_idx, perm, b_q_type_id, is_k_full, use_atomic_add, use_fp32_reduce, is_zp_float);
+}
+
+void gptq_marlin_gemm_with_workspace_(Tensor workspace, Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float) {
+    if (context::isGraphRecording()) {
+        GptqMarlinGemmWithWorkspace::execute(workspace, out, a, b, b_scales, global_scales, b_zeros, g_idx, perm, b_q_type_id, is_k_full, use_atomic_add, use_fp32_reduce, is_zp_float);
+    } else {
+        gptq_marlin_gemm_with_workspace_direct_(workspace, out, a, b, b_scales, global_scales, b_zeros, g_idx, perm, b_q_type_id, is_k_full, use_atomic_add, use_fp32_reduce, is_zp_float);
+    }
 }
 
 } // namespace infinicore::op

--- a/src/infinicore/ops/gptq_marlin_gemm/gptq_marlin_gemm_infiniop.cc
+++ b/src/infinicore/ops/gptq_marlin_gemm/gptq_marlin_gemm_infiniop.cc
@@ -47,6 +47,9 @@ void *plan(Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tenso
 
 void run(void *planned_meta) {
     auto planned = reinterpret_cast<PlannedMeta *>(planned_meta);
+    auto optional_data = [](graph::GraphTensor &tensor) -> void * {
+        return tensor->numel() == 0 ? nullptr : tensor->data();
+    };
 
     INFINICORE_CHECK_ERROR(infiniopGptqMarlinGemm(
         planned->descriptor->desc,
@@ -56,10 +59,10 @@ void run(void *planned_meta) {
         planned->a->data(),
         planned->b->data(),
         planned->b_scales->data(),
-        planned->global_scales->data(),
-        planned->b_zeros->data(),
-        planned->g_idx->data(),
-        planned->perm->data(),
+        optional_data(planned->global_scales),
+        optional_data(planned->b_zeros),
+        optional_data(planned->g_idx),
+        optional_data(planned->perm),
         planned->b_q_type_id,
         planned->is_k_full,
         planned->use_atomic_add,

--- a/src/infinicore/ops/gptq_marlin_gemm/gptq_marlin_gemm_infiniop.cc
+++ b/src/infinicore/ops/gptq_marlin_gemm/gptq_marlin_gemm_infiniop.cc
@@ -25,7 +25,9 @@ void *plan(Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tenso
         out->desc(), a->desc(),
         b->desc(), b_scales->desc(), global_scales->desc(), b_zeros->desc(), g_idx->desc(), perm->desc());
 
-    INFINIOP_WORKSPACE_TENSOR(workspace, GptqMarlinGemm, descriptor);
+    size_t workspace_size = 0;
+    INFINICORE_CHECK_ERROR(infiniopGetGptqMarlinGemmWorkspaceSize(descriptor->desc, &workspace_size));
+    Tensor workspace = Tensor::zeros({workspace_size}, DataType::U8, context::getDevice());
 
     return new PlannedMeta{
         descriptor,
@@ -79,3 +81,138 @@ void cleanup(void **planned_meta_ptr) {
 INFINICORE_GRAPH_OP_REGISTER_ALLDEVICE(GptqMarlinGemm, &plan, &run, &cleanup);
 
 } // namespace infinicore::op::gptq_marlin_gemm_impl::infiniop
+
+namespace infinicore::op::gptq_marlin_gemm_impl::infiniop {
+
+size_t workspace_size(Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm) {
+    size_t seed = hash_combine(out, a, b, b_scales, global_scales, b_zeros, g_idx, perm);
+
+    INFINIOP_CACHABLE_DESCRIPTOR_GET_OR_CREATE(
+        Descriptor, descriptor, GptqMarlinGemm,
+        seed,
+        out->desc(), a->desc(),
+        b->desc(), b_scales->desc(), global_scales->desc(), b_zeros->desc(), g_idx->desc(), perm->desc());
+
+    size_t size = 0;
+    INFINICORE_CHECK_ERROR(infiniopGetGptqMarlinGemmWorkspaceSize(descriptor->desc, &size));
+    return size;
+}
+
+struct PlannedWithWorkspaceMeta {
+    std::shared_ptr<Descriptor> descriptor;
+    graph::GraphTensor workspace, out, a, b, b_scales, global_scales, b_zeros, g_idx, perm;
+    int64_t b_q_type_id;
+    bool is_k_full, use_atomic_add, use_fp32_reduce, is_zp_float;
+};
+
+void *plan_with_workspace(Tensor workspace, Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float) {
+    size_t seed = hash_combine(out, a, b, b_scales, global_scales, b_zeros, g_idx, perm);
+
+    INFINIOP_CACHABLE_DESCRIPTOR_GET_OR_CREATE(
+        Descriptor, descriptor, GptqMarlinGemm,
+        seed,
+        out->desc(), a->desc(),
+        b->desc(), b_scales->desc(), global_scales->desc(), b_zeros->desc(), g_idx->desc(), perm->desc());
+
+    return new PlannedWithWorkspaceMeta{
+        descriptor,
+        graph::GraphTensor(workspace),
+        graph::GraphTensor(out),
+        graph::GraphTensor(a),
+        graph::GraphTensor(b),
+        graph::GraphTensor(b_scales),
+        graph::GraphTensor(global_scales),
+        graph::GraphTensor(b_zeros),
+        graph::GraphTensor(g_idx),
+        graph::GraphTensor(perm),
+        b_q_type_id,
+        is_k_full,
+        use_atomic_add,
+        use_fp32_reduce,
+        is_zp_float};
+}
+
+void run_with_workspace(void *planned_meta) {
+    auto planned = reinterpret_cast<PlannedWithWorkspaceMeta *>(planned_meta);
+    auto optional_data = [](graph::GraphTensor &tensor) -> void * {
+        return tensor->numel() == 0 ? nullptr : tensor->data();
+    };
+
+    INFINICORE_CHECK_ERROR(infiniopGptqMarlinGemm(
+        planned->descriptor->desc,
+        planned->workspace->data(),
+        planned->workspace->numel(),
+        planned->out->data(),
+        planned->a->data(),
+        planned->b->data(),
+        planned->b_scales->data(),
+        optional_data(planned->global_scales),
+        optional_data(planned->b_zeros),
+        optional_data(planned->g_idx),
+        optional_data(planned->perm),
+        planned->b_q_type_id,
+        planned->is_k_full,
+        planned->use_atomic_add,
+        planned->use_fp32_reduce,
+        planned->is_zp_float,
+        context::getStream()));
+}
+
+void cleanup_with_workspace(void **planned_meta_ptr) {
+    delete *reinterpret_cast<PlannedWithWorkspaceMeta **>(planned_meta_ptr);
+    *planned_meta_ptr = nullptr;
+}
+
+static bool registered_with_workspace = []() {
+    GptqMarlinGemmWithWorkspace::plan_dispatcher().registerAll(&plan_with_workspace, false);
+    GptqMarlinGemmWithWorkspace::run_dispatcher().registerAll(&run_with_workspace, false);
+    GptqMarlinGemmWithWorkspace::cleanup_dispatcher().registerAll(&cleanup_with_workspace, false);
+    return true;
+}();
+
+void direct_with_workspace(Tensor workspace, Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float) {
+    size_t seed = hash_combine(out, a, b, b_scales, global_scales, b_zeros, g_idx, perm);
+
+    INFINIOP_CACHABLE_DESCRIPTOR_GET_OR_CREATE(
+        Descriptor, descriptor, GptqMarlinGemm,
+        seed,
+        out->desc(), a->desc(),
+        b->desc(), b_scales->desc(), global_scales->desc(), b_zeros->desc(), g_idx->desc(), perm->desc());
+
+    auto optional_data = [](Tensor &tensor) -> void * {
+        return tensor->numel() == 0 ? nullptr : tensor->data();
+    };
+
+    INFINICORE_CHECK_ERROR(infiniopGptqMarlinGemm(
+        descriptor->desc,
+        workspace->data(),
+        workspace->numel(),
+        out->data(),
+        a->data(),
+        b->data(),
+        b_scales->data(),
+        optional_data(global_scales),
+        optional_data(b_zeros),
+        optional_data(g_idx),
+        optional_data(perm),
+        b_q_type_id,
+        is_k_full,
+        use_atomic_add,
+        use_fp32_reduce,
+        is_zp_float,
+        context::getStream()));
+}
+
+} // namespace infinicore::op::gptq_marlin_gemm_impl::infiniop
+
+namespace infinicore::op {
+
+size_t gptq_marlin_gemm_workspace_size(Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm) {
+    return gptq_marlin_gemm_impl::infiniop::workspace_size(out, a, b, b_scales, global_scales, b_zeros, g_idx, perm);
+}
+
+void gptq_marlin_gemm_with_workspace_direct_(Tensor workspace, Tensor out, const Tensor &a, const Tensor &b, Tensor &b_scales, Tensor &global_scales, Tensor &b_zeros, Tensor &g_idx, Tensor &perm, int64_t b_q_type_id, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float) {
+    gptq_marlin_gemm_impl::infiniop::direct_with_workspace(workspace, out, a, b, b_scales, global_scales, b_zeros, g_idx, perm, b_q_type_id, is_k_full, use_atomic_add, use_fp32_reduce, is_zp_float);
+}
+
+} // namespace infinicore::op

--- a/src/infiniop/ops/awq_marlin_gemm/nvidia/awq_marlin_gemm_nvidia.cu
+++ b/src/infiniop/ops/awq_marlin_gemm/nvidia/awq_marlin_gemm_nvidia.cu
@@ -178,8 +178,7 @@ infiniStatus_t awq_marlin_gemm_kernel(
     const int total_bytes = c_tmp_bytes + a_tmp_bytes + workspace_bytes;
     // ===================== 3. 单次 cudaMalloc 分配 =====================
     if (total_bytes > 0) {
-
-        cudaMemset(total_buffer, 0, total_bytes);
+        cudaMemsetAsync(total_buffer, 0, total_bytes, stream);
     }
     // ===================== 4. 手动切分指针（核心！） =====================
     uint8_t *ptr = reinterpret_cast<uint8_t *>(total_buffer);

--- a/src/infiniop/ops/awq_marlin_gemm/nvidia/awq_marlin_gemm_nvidia.cu
+++ b/src/infiniop/ops/awq_marlin_gemm/nvidia/awq_marlin_gemm_nvidia.cu
@@ -116,6 +116,7 @@ infiniStatus_t awq_marlin_gemm_kernel(
     }
 
     int device_id = 0;
+    cudaGetDevice(&device_id);
     // thread_k: `k` size of a thread_tile in `weights` (can usually be left as
     // auto -1)
     int thread_k = -1;
@@ -300,6 +301,7 @@ infiniStatus_t Descriptor::create(
     int c_tmp_bytes = 0;
 
     int device_id = 0;
+    cudaGetDevice(&device_id);
     int sms = -1;
     cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, device_id);
     int workspace_bytes = sms * sizeof(int64_t);

--- a/src/infiniop/ops/awq_marlin_gemm/nvidia/awq_marlin_gemm_nvidia.cu
+++ b/src/infiniop/ops/awq_marlin_gemm/nvidia/awq_marlin_gemm_nvidia.cu
@@ -66,7 +66,6 @@ infiniStatus_t awq_marlin_gemm_kernel(
         if constexpr (std::is_same<Tdata, __nv_fp8_e4m3>::value) {
             s_type_id = vllm::kFE4M3fn.id();
         } else if constexpr (std::is_same<Tdata, uint8_t>::value) {
-            printf("b_scales.scalar_type() == at::ScalarType::Float8_e8m0fnu\n");
             s_type_id = vllm::kFE8M0fnu.id();
         } else {
             host::RuntimeCheck(false,
@@ -174,12 +173,7 @@ infiniStatus_t awq_marlin_gemm_kernel(
         }
     }
 
-    int workspace_bytes = sms * sizeof(int64_t);
-    const int total_bytes = c_tmp_bytes + a_tmp_bytes + workspace_bytes;
-    // ===================== 3. 单次 cudaMalloc 分配 =====================
-    if (total_bytes > 0) {
-        cudaMemsetAsync(total_buffer, 0, total_bytes, stream);
-    }
+    int workspace_bytes = sms * sizeof(int);
     // ===================== 4. 手动切分指针（核心！） =====================
     uint8_t *ptr = reinterpret_cast<uint8_t *>(total_buffer);
     // 分配 c_tmp
@@ -226,8 +220,7 @@ infiniStatus_t awq_marlin_gemm_kernel(
 
     if (has_zp && is_zp_float) {
         if constexpr (!std::is_same<scalar_t, half>::value) {
-            printf("Computation a_type must be float16 (half) when using float zero "
-                   "points.\n");
+            host::RuntimeCheck(false, "Computation a_type must be float16 (half) when using float zero points.");
         }
     }
 
@@ -303,13 +296,15 @@ infiniStatus_t Descriptor::create(
     cudaGetDevice(&device_id);
     int sms = -1;
     cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, device_id);
-    int workspace_bytes = sms * sizeof(int64_t);
+    int workspace_bytes = sms * sizeof(int);
     int max_m_block_size = (size_m + 16 - 1) / 16 * 16;
     max_m_block_size = min(max_m_block_size, 64);
     int max_c_tmp_size = sms * max_m_block_size * MARLIN_NAMESPACE_NAME::max_thread_n;
     c_tmp_bytes = max_c_tmp_size * sizeof(float);
 
-    a_tmp_bytes = size_m * size_k * infiniSizeOf(a_desc->dtype());
+    if (g_idx_desc->numel() > 0 && perm_desc->numel() > 0) {
+        a_tmp_bytes = size_m * size_k * infiniSizeOf(a_desc->dtype());
+    }
 
     size_t workspace_size = c_tmp_bytes + a_tmp_bytes + workspace_bytes;
 

--- a/src/infiniop/ops/awq_marlin_gemm/nvidia/generate_kernels.py
+++ b/src/infiniop/ops/awq_marlin_gemm/nvidia/generate_kernels.py
@@ -32,15 +32,12 @@ FILE_HEAD_COMMENT = """
 """.lstrip()
 
 
-FILE_HEAD = (
-    FILE_HEAD_COMMENT
-    + """
+FILE_HEAD = FILE_HEAD_COMMENT + """
 #include "../marlin/kernel.h"
 #include "../marlin/marlin_template.h"
 
 namespace MARLIN_NAMESPACE_NAME {
 """
-)
 
 TEMPLATE = (
     "template __global__ void Marlin<"

--- a/src/infiniop/ops/awq_marlin_gemm/nvidia/kernel.cuh
+++ b/src/infiniop/ops/awq_marlin_gemm/nvidia/kernel.cuh
@@ -515,8 +515,15 @@ void marlin_mm(const void *A, const void *B, void *C, void *C_tmp, void *b_bias,
                                ", num_threads = ", num_threads, ", num_bits = ", num_bits);
         }
 
-        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                             max_shared_mem_new);
+        cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+        host::RuntimeCheck(
+            cudaStreamIsCapturing(stream, &capture_status) == cudaSuccess,
+            "cudaStreamIsCapturing failed");
+        if (capture_status == cudaStreamCaptureStatusNone) {
+            host::RuntimeCheck(
+                cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem_new) == cudaSuccess,
+                "cudaFuncSetAttribute failed");
+        }
 
         bool part_use_atomic_add = use_atomic_add && div_ceil(prob_m_split, 64) * prob_n <= 2048;
 

--- a/src/infiniop/ops/gptq_marlin_gemm/nvidia/gptq_marlin_gemm_nvidia.cu
+++ b/src/infiniop/ops/gptq_marlin_gemm/nvidia/gptq_marlin_gemm_nvidia.cu
@@ -993,14 +993,6 @@ infiniStatus_t gptq_marlin_gemm_kernel(void *c,
     const size_t workspace_elems = (size_t)sms * max_blocks_per_sm;
     const size_t workspace_bytes = workspace_elems * sizeof(int);
 
-    // ===================== 2. 计算总内存大小 =====================
-    const size_t total_bytes = c_tmp_bytes + a_tmp_bytes + workspace_bytes;
-
-    // ===================== 3. 单次 cudaMalloc 分配 =====================
-    if (total_bytes > 0) {
-        cudaMemsetAsync(total_buffer, 0, total_bytes, stream);
-    }
-
     // ===================== 4. 手动切分指针（核心！） =====================
     uint8_t *ptr = reinterpret_cast<uint8_t *>(total_buffer);
 
@@ -1088,7 +1080,10 @@ infiniStatus_t Descriptor::create(
     max_m_block = min(max_m_block, 64);
     const size_t c_elems = (size_t)sms * max_m_block * _MAX_THREAD_N;
     size_t c_tmp_bytes = c_elems * sizeof(float);
-    size_t a_tmp_bytes = (size_t)a_desc->dim(0) * a_desc->dim(1) * infiniSizeOf(a_desc->dtype());
+    size_t a_tmp_bytes = 0;
+    if (g_idx_desc->numel() > 0 && perm_desc->numel() > 0) {
+        a_tmp_bytes = (size_t)a_desc->dim(0) * a_desc->dim(1) * infiniSizeOf(a_desc->dtype());
+    }
     const size_t workspace_elems = (size_t)sms * max_blocks_per_sm;
     const size_t workspace_bytes = workspace_elems * sizeof(int);
     size_t workspace_size = c_tmp_bytes + a_tmp_bytes + workspace_bytes;

--- a/src/infiniop/ops/gptq_marlin_gemm/nvidia/gptq_marlin_gemm_nvidia.cu
+++ b/src/infiniop/ops/gptq_marlin_gemm/nvidia/gptq_marlin_gemm_nvidia.cu
@@ -890,6 +890,7 @@ void gptq_marlin_gemm(const void *a,
         device::marlin::min_thread_n);
 
     int device_id = 0;
+    RuntimeDeviceCheck(cudaGetDevice(&device_id));
     int sms = -1;
     RuntimeDeviceCheck(cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, device_id));
     // RuntimeCheck(workspace.size(0) >= sms, "workspace.size(0) = ", workspace.size(0), " is below min_workspace_size = ", sms);

--- a/src/infiniop/ops/gptq_marlin_gemm/nvidia/gptq_marlin_gemm_nvidia.cu
+++ b/src/infiniop/ops/gptq_marlin_gemm/nvidia/gptq_marlin_gemm_nvidia.cu
@@ -742,8 +742,12 @@ void marlin_mm(
                 num_bits);
         }
 
-        host::RuntimeDeviceCheck(
-            cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem_new));
+        cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+        host::RuntimeDeviceCheck(cudaStreamIsCapturing(stream, &capture_status));
+        if (capture_status == cudaStreamCaptureStatusNone) {
+            host::RuntimeDeviceCheck(
+                cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem_new));
+        }
 
         bool part_use_atomic_add = use_atomic_add && div_ceil(prob_m_split, 64) * prob_n <= 2048;
 
@@ -994,7 +998,7 @@ infiniStatus_t gptq_marlin_gemm_kernel(void *c,
 
     // ===================== 3. 单次 cudaMalloc 分配 =====================
     if (total_bytes > 0) {
-        cudaMemset(total_buffer, 0, total_bytes);
+        cudaMemsetAsync(total_buffer, 0, total_bytes, stream);
     }
 
     // ===================== 4. 手动切分指针（核心！） =====================

--- a/src/infiniop/ops/gptq_marlin_gemm/sgl_kernel/tensor.h
+++ b/src/infiniop/ops/gptq_marlin_gemm/sgl_kernel/tensor.h
@@ -83,10 +83,6 @@ inline constexpr const char *kDeviceStringMap[] = {
 
 constexpr int kMaxDeviceType = 16;
 
-struct PrintableDevice {
-    DLDevice device;
-};
-
 template <typename T>
 struct _dtype_trait;
 
@@ -171,10 +167,6 @@ inline std::ostream &operator<<(std::ostream &os, DLDevice device) {
         os << ":" << device.device_id;
     }
     return os;
-}
-
-inline std::ostream &operator<<(std::ostream &os, details::PrintableDevice pd) {
-    return os << pd.device;
 }
 
 template <typename T>

--- a/src/infiniop/ops/gptq_marlin_gemm/sgl_kernel/utils.h
+++ b/src/infiniop/ops/gptq_marlin_gemm/sgl_kernel/utils.h
@@ -75,8 +75,7 @@ inline std::ostream &operator<<(std::ostream &os, PrintableDevice pd) {
     static const char *device_names[] = {
         "", "cpu", "cuda", "cuda_host", "opencl", "vulkan",
         "metal", "vpi", "rocm", "rocm_host", "ext_dev",
-        "cuda_managed", "oneapi", "webgpu", "hexagon", "maia", "trn"
-    };
+        "cuda_managed", "oneapi", "webgpu", "hexagon", "maia", "trn"};
     if (code >= 0 && code <= 16) {
         os << device_names[code];
         if (pd.device.device_id >= 0 && code != 1 && code != 0) {

--- a/src/infiniop/ops/gptq_marlin_gemm/sgl_kernel/utils.h
+++ b/src/infiniop/ops/gptq_marlin_gemm/sgl_kernel/utils.h
@@ -9,6 +9,7 @@
 /// - `div_ceil` - integer ceiling division.
 /// - `dtype_bytes` - byte width of a `DLDataType`.
 /// - `irange` - Python-style integer range for range-for loops.
+/// - `PrintableDevice` - wrapper for outputting device info to streams (NVIDIA only).
 
 #pragma once
 
@@ -45,19 +46,51 @@
 #include "source_location.h"
 #endif
 
-#include "../dlpack/dlpack.h"
-#include <type_traits>
-// #include <concepts>
+#include <concepts>
 #include <cstddef>
+#include <dlpack/dlpack.h>
 #include <ostream>
-// #include <ranges>
+#include <ranges>
 #include <sstream>
+#include <type_traits>
 #include <utility>
 
 namespace host {
 
 template <typename>
 inline constexpr bool dependent_false_v = false;
+
+#if defined(ENABLE_NVIDIA_API)
+
+namespace details {
+
+/// \brief PrintableDevice wrapper for outputting device info to streams.
+struct PrintableDevice {
+    DLDevice device;
+};
+
+/// \brief Stream output operator for PrintableDevice.
+inline std::ostream &operator<<(std::ostream &os, PrintableDevice pd) {
+    int code = static_cast<int>(pd.device.device_type);
+    static const char *device_names[] = {
+        "", "cpu", "cuda", "cuda_host", "opencl", "vulkan",
+        "metal", "vpi", "rocm", "rocm_host", "ext_dev",
+        "cuda_managed", "oneapi", "webgpu", "hexagon", "maia", "trn"
+    };
+    if (code >= 0 && code <= 16) {
+        os << device_names[code];
+        if (pd.device.device_id >= 0 && code != 1 && code != 0) {
+            os << ":" << pd.device.device_id;
+        }
+    } else {
+        os << "device(" << code << "," << pd.device.device_id << ")";
+    }
+    return os;
+}
+
+} // namespace details
+
+#endif // ENABLE_NVIDIA_API
 
 /// \brief Source-location wrapper for debug/error messages.
 struct DebugInfo : public source_location_t {
@@ -175,6 +208,7 @@ inline auto dtype_bytes(DLDataType dtype) -> std::size_t {
     return static_cast<std::size_t>(dtype.bits / 8);
 }
 
+// Pure C++11 compatible irange - removes std::ranges/std::integral for older CUDA compilers
 template <typename T>
 struct IntegerRange {
     T start_;

--- a/test/infiniop/awq_marlin_gemm.py
+++ b/test/infiniop/awq_marlin_gemm.py
@@ -23,7 +23,6 @@ from libinfiniop.scalar_type import scalar_types, ScalarType
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Tuple, Union
 import numpy as np
 
-
 _TEST_CASES_SUBSET_INPUT = [
     # (size_m, size_k, size_n, group_size, quant_type)
     (32, 1024, 2048, 128, scalar_types.uint4b8),

--- a/test/infiniop/gptq_marlin_gemm.py
+++ b/test/infiniop/gptq_marlin_gemm.py
@@ -22,7 +22,6 @@ from libinfiniop.scalar_type import scalar_types, ScalarType
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Tuple, Union
 import numpy as np
 
-
 # ==============================================================================
 #  Configuration
 # ==============================================================================


### PR DESCRIPTION
## Summary

This PR adds the InfiniCore-side runtime support needed by InfiniLM to run AWQ/GPTQ Marlin inference paths.

Main changes:

- Add explicit reusable workspace APIs for GPTQ Marlin GEMM:
  - `gptq_marlin_gemm_workspace_size`
  - `gptq_marlin_gemm_with_workspace_`
  - direct workspace-backed execution path
- Update AWQ/GPTQ Marlin CUDA kernels to avoid clearing the whole temporary buffer on every launch.
- Keep only the required Marlin lock/workspace region as caller-managed runtime state.
- Add `context::trimMemory()` so framework code can return freed cached allocator blocks after weight processing.
- Add lightweight `Module::state_dict_keys()` to query parameter names without constructing a full tensor-owning state dict.
- Fix NVIDIA compilation for `PrintableDevice` stream output.
- Format touched Marlin sources and generated Python scripts.

## Motivation

InfiniLM needs a stable way to provide persistent Marlin workspace from the framework layer. Allocating and clearing workspace inside every GEMM is expensive and makes CUDA graph capture/replay harder to control.

This PR moves workspace ownership to the caller and exposes the workspace size/query path needed by InfiniLM.

## Notes

The current Marlin kernels still require a zero-initialized lock/workspace region before launch. InfiniLM handles that reset at graph capture/replay boundaries for now. A future optimization should make the lock buffer globally reusable or make the kernel self-reset lock state.

## Testing

- Existing InfiniCore build was tested by the integrator during development.
- `git diff --check` passes.
- Formatting was applied to touched C++/CUDA/Python files.