### PR TITLE
fix: wire InfiniOps paged attention workspace

### DIFF
--- a/src/infinicore/ops/paged_attention/paged_attention_infiniops.cc
+++ b/src/infinicore/ops/paged_attention/paged_attention_infiniops.cc
@@ -5,15 +5,27 @@
 
 #include "base/paged_attention_infinilm.h"
 
+#include <cstddef>
 #include <optional>
 
 namespace infinicore::op::paged_attention_impl::infiniops {
 namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
+
+constexpr std::size_t kMaxPagedAttentionSplits = 8;
+
+std::size_t WorkspaceSizeInBytes(const Tensor &q) {
+    return kMaxPagedAttentionSplits
+         * static_cast<std::size_t>(q->size(0))
+         * static_cast<std::size_t>(q->size(1))
+         * static_cast<std::size_t>(q->size(2) + 2)
+         * sizeof(float);
+}
+
 struct PlannedMeta {
     TensorMeta out, q, k_cache, v_cache, block_tables, cache_lens;
     std::optional<TensorMeta> alibi_slopes;
-    graph::GraphTensor out_tensor, q_tensor, k_cache_tensor, v_cache_tensor, block_tables_tensor, cache_lens_tensor;
+    graph::GraphTensor workspace, out_tensor, q_tensor, k_cache_tensor, v_cache_tensor, block_tables_tensor, cache_lens_tensor;
     std::optional<graph::GraphTensor> alibi_slopes_tensor;
     float scale;
 };
@@ -35,6 +47,7 @@ void *plan(Tensor out,
     return new PlannedMeta{
         TensorMeta(out), TensorMeta(q), TensorMeta(k_cache), TensorMeta(v_cache), TensorMeta(block_tables), TensorMeta(cache_lens),
         alibi_slopes ? std::optional<TensorMeta>{TensorMeta(*alibi_slopes)} : std::nullopt,
+        graph::GraphTensor(Tensor::empty({WorkspaceSizeInBytes(q)}, DataType::U8, out->device())),
         graph::GraphTensor(out), graph::GraphTensor(q), graph::GraphTensor(k_cache), graph::GraphTensor(v_cache), graph::GraphTensor(block_tables), graph::GraphTensor(cache_lens),
         alibi_slopes ? std::optional<graph::GraphTensor>{graph::GraphTensor(*alibi_slopes)} : std::nullopt,
         scale};
@@ -44,6 +57,8 @@ void run(void *planned_meta) {
     auto planned = reinterpret_cast<PlannedMeta *>(planned_meta);
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
+    handle.set_workspace(planned->workspace->data());
+    handle.set_workspace_size_in_bytes(planned->workspace->numel());
     infini::ops::Config config;
     infini::ops::PagedAttentionInfinilm::Call(
         handle,

--- a/xmake.lua
+++ b/xmake.lua
@@ -296,6 +296,25 @@ local function get_standalone_infinirt_root()
     return nil
 end
 
+local function get_infiniops_cuda_architectures()
+    local arch_opt = get_config("cuda_arch")
+    if not arch_opt or arch_opt == "" then
+        return nil
+    end
+
+    local cmake_archs = {}
+    for _, arch in ipairs(arch_opt:gsub(";", ","):split(",")) do
+        local cmake_arch = arch:trim():match("^sm_(%d+a?)$")
+        if cmake_arch then
+            table.insert(cmake_archs, cmake_arch)
+        end
+    end
+    if #cmake_archs == 0 then
+        return nil
+    end
+    return table.concat(cmake_archs, ";")
+end
+
 local infiniops_external_built = false
 
 local function build_infiniops_external(xmake_os)
@@ -317,6 +336,10 @@ local function build_infiniops_external(xmake_os)
     local infiniops_ops = os.getenv("INFINI_OPS_OPS")
     if infiniops_ops and #infiniops_ops > 0 then
         table.insert(cmake_config_args, "-DINFINI_OPS_OPS=" .. infiniops_ops)
+    end
+    local cmake_cuda_architectures = get_infiniops_cuda_architectures()
+    if cmake_cuda_architectures and cmake_cuda_architectures ~= "" then
+        table.insert(cmake_config_args, "-DCMAKE_CUDA_ARCHITECTURES=" .. cmake_cuda_architectures)
     end
     if infinirt_root and infinirt_root ~= "" then
         table.insert(cmake_config_args, "-DINFINI_RT_ROOT=" .. infinirt_root)


### PR DESCRIPTION
## Summary

- Allocate and pass workspace for the InfiniOps `PagedAttentionInfinilm` call.
- Propagate xmake `--cuda_arch` into the external InfiniOps CMake build through `CMAKE_CUDA_ARCHITECTURES`.

## Motivation

The new InfiniOps InfiniLM paged attention decode path uses a split-KV fast path for head size 128 when sufficient workspace is provided. InfiniCore currently calls the operator without workspace, so InfiniOps falls back to the slower decode path. In addition, the external InfiniOps CMake build defaults to `sm_75` unless `CMAKE_CUDA_ARCHITECTURES` is set, even when InfiniCore is configured with `--cuda_arch=sm_80`.

Together, these two integration gaps explain the large performance loss seen after switching paged attention to InfiniOps.

This PR is the InfiniCore integration side. The InfiniOps split-count tuning is tracked separately in InfiniTensor/InfiniOps#741. After that PR lands, InfiniCore will also need the `submodules/InfiniOps` pointer bumped to a commit that contains it to reproduce the final benchmark numbers from a fresh checkout.

## Validation

On `ssh nvidia-1`, using `/tmp/codex-infinicore-perf-nvidia1-20260623-1703`:

```text
GPU_ID=0 KEEP_BUILD=0 BASE=/tmp/codex-infinicore-perf-nvidia1-20260623-1703 \
  bash scripts/docker_build_core.sh ops true

infinicore import ok
CMAKE_CUDA_ARCHITECTURES:UNINITIALIZED=80
```

After rebuilding InfiniLM against the rebuilt InfiniCore root:

```text
GPU_ID=0 BASE=/tmp/codex-infinicore-perf-nvidia1-20260623-1703 \
  bash scripts/docker_build_lm.sh ops

imports ok
```

Smoke benchmark:

```text
python examples/bench.py --device nvidia \
  --model=/data-aisoft/mechdancer/models/9g_8b_thinking_llama \
  --enable-paged-attn --enable-graph \
  --input-len=32,32 --output-len=256 --batch-size=1

Decode throughput: 85.71 tok/s, 85.86 tok/s
```

Formatting/checks:

```text
clang-format-18 --dry-run -Werror src/infinicore/ops/paged_attention/paged_attention_infiniops.cc
git diff --check
```

Both passed.

`ruff format --check .` and `ruff check .` still fail on existing Python files unrelated to this PR; no Python files are changed here.

## Performance Notes

With this PR plus InfiniTensor/InfiniOps#741 and a local submodule checkout containing #741, the full requested InfiniLM benchmark command group completed on `nvidia-1`. Decode throughput deltas versus no-InfiniOps baseline:

| Case | Avg | Warm Avg |
| --- | ---: | ---: |
| 8B bs1 | +7.83% | +8.33% |
| 8B bs4 | +2.62% | +5.35% |
| 8B bs16 | -2.66% | +0.93% |
| 8B bs64 | -1.64% | +1.33% |
| 70B bs1 | +9.81% | +10.46% |
| 70B bs4 | +8.24% | +8.78% |
| 70B bs16 | -0.71% | -0.66% |

The large negative first-sample outliers in some 8B batches are cold-start/first graph-capture effects; the duplicated warm cases return to near parity or better.
