### PR TITLE
issue/1320 - support InfiniOps standalone InfiniRT across platforms

### DIFF
--- a/src/infinicore/ops/add/add_infiniops.cc
+++ b/src/infinicore/ops/add/add_infiniops.cc
@@ -16,7 +16,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor c, const Tensor &a, const Tensor &b) {
-    INFINICORE_ASSERT(c->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(c->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(c, a, b);
 
     return new PlannedMeta{
@@ -49,9 +49,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    Add::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    Add::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    Add::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(Add::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(Add::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(Add::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 

--- a/src/infinicore/ops/add_rms_norm/add_rms_norm_infiniops.cc
+++ b/src/infinicore/ops/add_rms_norm/add_rms_norm_infiniops.cc
@@ -21,7 +21,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor out, Tensor residual, const Tensor &a, const Tensor &b, const Tensor &weight, float epsilon) {
-    INFINICORE_ASSERT(out->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(out->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(out, residual, a, b, weight);
 
     return new PlannedMeta{
@@ -62,9 +62,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    AddRMSNorm::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    AddRMSNorm::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    AddRMSNorm::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(AddRMSNorm::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(AddRMSNorm::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(AddRMSNorm::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 

--- a/src/infinicore/ops/causal_softmax/causal_softmax_infiniops.cc
+++ b/src/infinicore/ops/causal_softmax/causal_softmax_infiniops.cc
@@ -18,7 +18,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor output, const Tensor &input) {
-    INFINICORE_ASSERT(output->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(output->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input);
 
     return new PlannedMeta{
@@ -48,9 +48,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    CausalSoftmax::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    CausalSoftmax::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    CausalSoftmax::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(CausalSoftmax::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(CausalSoftmax::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(CausalSoftmax::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 

--- a/src/infinicore/ops/conv2d/conv2d_infiniops.cc
+++ b/src/infinicore/ops/conv2d/conv2d_infiniops.cc
@@ -30,7 +30,7 @@ void calculate(Tensor output,
                const size_t *strides,
                const size_t *dilations,
                size_t n) {
-    INFINICORE_ASSERT(output->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(output->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input, weight);
     if (bias) {
         INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, bias);
@@ -64,7 +64,7 @@ void calculate(Tensor output,
 } // namespace
 
 static bool registered = []() {
-    Conv2d::dispatcher().registerDevice(Device::Type::NVIDIA, &calculate);
+    ::infinicore::op::infiniops::registerSupportedDevices(Conv2d::dispatcher(), &calculate);
     return true;
 }();
 

--- a/src/infinicore/ops/embedding/embedding_infiniops.cc
+++ b/src/infinicore/ops/embedding/embedding_infiniops.cc
@@ -18,7 +18,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor out, const Tensor &input, const Tensor &weight) {
-    INFINICORE_ASSERT(out->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(out->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(out, input, weight);
 
     return new PlannedMeta{
@@ -51,9 +51,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    Embedding::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    Embedding::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    Embedding::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(Embedding::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(Embedding::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(Embedding::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 

--- a/src/infinicore/ops/gelu/gelu_infiniops.cc
+++ b/src/infinicore/ops/gelu/gelu_infiniops.cc
@@ -13,7 +13,7 @@ namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 
 void calculate(Tensor output, Tensor input) {
-    INFINICORE_ASSERT(output->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(output->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input);
 
     infini::ops::Handle handle;
@@ -33,7 +33,7 @@ void calculate(Tensor output, Tensor input) {
 } // namespace
 
 static bool registered = []() {
-    Gelu::dispatcher().registerDevice(Device::Type::NVIDIA, &calculate);
+    ::infinicore::op::infiniops::registerSupportedDevices(Gelu::dispatcher(), &calculate);
     return true;
 }();
 

--- a/src/infinicore/ops/gelutanh/gelutanh_infiniops.cc
+++ b/src/infinicore/ops/gelutanh/gelutanh_infiniops.cc
@@ -11,7 +11,7 @@ namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 
 void calculate(Tensor output, Tensor input) {
-    INFINICORE_ASSERT(output->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(output->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input);
 
     infini::ops::Handle handle;
@@ -30,7 +30,7 @@ void calculate(Tensor output, Tensor input) {
 } // namespace
 
 static bool registered = []() {
-    GeluTanh::dispatcher().registerDevice(Device::Type::NVIDIA, &calculate);
+    ::infinicore::op::infiniops::registerSupportedDevices(GeluTanh::dispatcher(), &calculate);
     return true;
 }();
 

--- a/src/infinicore/ops/gemm/gemm_infiniops.cc
+++ b/src/infinicore/ops/gemm/gemm_infiniops.cc
@@ -19,7 +19,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor c, const Tensor &a, const Tensor &b, float alpha, float beta) {
-    INFINICORE_ASSERT(c->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(c->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(c, a, b);
 
     return new PlannedMeta{
@@ -58,9 +58,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    Gemm::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    Gemm::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    Gemm::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(Gemm::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(Gemm::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(Gemm::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 

--- a/src/infinicore/ops/infiniops_impl.hpp
+++ b/src/infinicore/ops/infiniops_impl.hpp
@@ -46,8 +46,38 @@ inline infini::ops::DataType toInfiniOpsDtype(DataType dtype) {
 }
 
 inline infini::ops::Device toInfiniOpsDevice(const Device &device) {
-    INFINICORE_ASSERT(device.getType() == Device::Type::NVIDIA);
-    return infini::ops::Device{infini::ops::Device::Type::kNvidia, static_cast<int>(device.getIndex())};
+    switch (device.getType()) {
+    case Device::Type::NVIDIA:
+        return infini::ops::Device{infini::ops::Device::Type::kNvidia, static_cast<int>(device.getIndex())};
+    case Device::Type::METAX:
+        return infini::ops::Device{infini::ops::Device::Type::kMetax, static_cast<int>(device.getIndex())};
+    case Device::Type::MOORE:
+        return infini::ops::Device{infini::ops::Device::Type::kMoore, static_cast<int>(device.getIndex())};
+    case Device::Type::ILUVATAR:
+        return infini::ops::Device{infini::ops::Device::Type::kIluvatar, static_cast<int>(device.getIndex())};
+    default:
+        throw std::runtime_error("InfiniOps backend does not support this device type.");
+    }
+}
+
+inline bool isSupportedDevice(Device::Type device_type) {
+    switch (device_type) {
+    case Device::Type::NVIDIA:
+    case Device::Type::METAX:
+    case Device::Type::MOORE:
+    case Device::Type::ILUVATAR:
+        return true;
+    default:
+        return false;
+    }
+}
+
+template <typename Dispatcher, typename Function>
+void registerSupportedDevices(Dispatcher &dispatcher, Function function) {
+    dispatcher.registerDevice(Device::Type::NVIDIA, function);
+    dispatcher.registerDevice(Device::Type::METAX, function);
+    dispatcher.registerDevice(Device::Type::MOORE, function);
+    dispatcher.registerDevice(Device::Type::ILUVATAR, function);
 }
 
 struct TensorMeta {

--- a/src/infinicore/ops/kv_caching/kv_caching_infiniops.cc
+++ b/src/infinicore/ops/kv_caching/kv_caching_infiniops.cc
@@ -15,7 +15,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor k_cache, Tensor v_cache, const Tensor &k, const Tensor &v, const Tensor &past_kv_lengths) {
-    INFINICORE_ASSERT(k_cache->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(k_cache->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(k_cache, v_cache, k, v, past_kv_lengths);
     return new PlannedMeta{TensorMeta(k_cache), TensorMeta(v_cache), TensorMeta(k), TensorMeta(v), TensorMeta(past_kv_lengths), graph::GraphTensor(k_cache), graph::GraphTensor(v_cache), graph::GraphTensor(k), graph::GraphTensor(v), graph::GraphTensor(past_kv_lengths)};
 }
@@ -41,9 +41,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    KVCaching::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    KVCaching::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    KVCaching::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(KVCaching::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(KVCaching::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(KVCaching::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 } // namespace infinicore::op::kv_caching_impl::infiniops

--- a/src/infinicore/ops/paged_attention/paged_attention_infiniops.cc
+++ b/src/infinicore/ops/paged_attention/paged_attention_infiniops.cc
@@ -39,7 +39,7 @@ void *plan(Tensor out,
            const Tensor &cache_lens,
            std::optional<Tensor> alibi_slopes,
            float scale) {
-    INFINICORE_ASSERT(out->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(out->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(out, q, k_cache, v_cache, block_tables, cache_lens);
     if (alibi_slopes) {
         INFINICORE_ASSERT_TENSORS_SAME_DEVICE(out, *alibi_slopes);
@@ -79,9 +79,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    PagedAttention::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    PagedAttention::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    PagedAttention::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(PagedAttention::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(PagedAttention::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(PagedAttention::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 } // namespace infinicore::op::paged_attention_impl::infiniops

--- a/src/infinicore/ops/paged_attention_prefill/paged_attention_prefill_infiniops.cc
+++ b/src/infinicore/ops/paged_attention_prefill/paged_attention_prefill_infiniops.cc
@@ -21,7 +21,7 @@ void calculate(Tensor out,
                Tensor cum_seqlens_q,
                std::optional<Tensor> alibi_slopes,
                float scale) {
-    INFINICORE_ASSERT(out->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(out->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(out, q, k_cache, v_cache, block_tables, kv_lens, cum_seqlens_q);
     if (alibi_slopes) {
         INFINICORE_ASSERT_TENSORS_SAME_DEVICE(out, *alibi_slopes);
@@ -60,7 +60,7 @@ void calculate(Tensor out,
 } // namespace
 
 static bool registered = []() {
-    PagedAttentionPrefill::dispatcher().registerDevice(Device::Type::NVIDIA, &calculate);
+    ::infinicore::op::infiniops::registerSupportedDevices(PagedAttentionPrefill::dispatcher(), &calculate);
     return true;
 }();
 

--- a/src/infinicore/ops/paged_caching/paged_caching_infiniops.cc
+++ b/src/infinicore/ops/paged_caching/paged_caching_infiniops.cc
@@ -15,7 +15,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor k_cache, Tensor v_cache, const Tensor &k, const Tensor &v, const Tensor &slot_mapping) {
-    INFINICORE_ASSERT(k_cache->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(k_cache->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(k_cache, v_cache, k, v, slot_mapping);
     return new PlannedMeta{TensorMeta(k_cache), TensorMeta(v_cache), TensorMeta(k), TensorMeta(v), TensorMeta(slot_mapping), graph::GraphTensor(k_cache), graph::GraphTensor(v_cache), graph::GraphTensor(k), graph::GraphTensor(v), graph::GraphTensor(slot_mapping)};
 }
@@ -41,9 +41,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    PagedCaching::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    PagedCaching::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    PagedCaching::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(PagedCaching::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(PagedCaching::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(PagedCaching::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 } // namespace infinicore::op::paged_caching_impl::infiniops

--- a/src/infinicore/ops/random_sample/random_sample_infiniops.cc
+++ b/src/infinicore/ops/random_sample/random_sample_infiniops.cc
@@ -11,7 +11,7 @@ namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 
 void calculate(Tensor indices, Tensor logits, float random_val, float topp, int topk, float temperature) {
-    INFINICORE_ASSERT(indices->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(indices->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(indices, logits);
 
     infini::ops::Handle handle;
@@ -34,7 +34,7 @@ void calculate(Tensor indices, Tensor logits, float random_val, float topp, int 
 } // namespace
 
 static bool registered = []() {
-    RandomSample::dispatcher().registerDevice(Device::Type::NVIDIA, &calculate);
+    ::infinicore::op::infiniops::registerSupportedDevices(RandomSample::dispatcher(), &calculate);
     return true;
 }();
 

--- a/src/infinicore/ops/rearrange/rearrange_infiniops.cc
+++ b/src/infinicore/ops/rearrange/rearrange_infiniops.cc
@@ -15,7 +15,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor y, const Tensor &x) {
-    INFINICORE_ASSERT(y->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(y->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(y, x);
     return new PlannedMeta{TensorMeta(y), TensorMeta(x), graph::GraphTensor(y), graph::GraphTensor(x)};
 }

--- a/src/infinicore/ops/relu/relu_infiniops.cc
+++ b/src/infinicore/ops/relu/relu_infiniops.cc
@@ -11,7 +11,7 @@ namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 
 void calculate(Tensor output, Tensor input) {
-    INFINICORE_ASSERT(output->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(output->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input);
 
     infini::ops::Handle handle;
@@ -30,7 +30,7 @@ void calculate(Tensor output, Tensor input) {
 } // namespace
 
 static bool registered = []() {
-    Relu::dispatcher().registerDevice(Device::Type::NVIDIA, &calculate);
+    ::infinicore::op::infiniops::registerSupportedDevices(Relu::dispatcher(), &calculate);
     return true;
 }();
 

--- a/src/infinicore/ops/rms_norm/rms_norm_infiniops.cc
+++ b/src/infinicore/ops/rms_norm/rms_norm_infiniops.cc
@@ -19,7 +19,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor y, const Tensor &x, const Tensor &weight, float epsilon) {
-    INFINICORE_ASSERT(y->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(y->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(y, x, weight);
 
     return new PlannedMeta{
@@ -54,9 +54,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    RMSNorm::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    RMSNorm::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    RMSNorm::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(RMSNorm::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(RMSNorm::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(RMSNorm::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 

--- a/src/infinicore/ops/rope/rope_infiniops.cc
+++ b/src/infinicore/ops/rope/rope_infiniops.cc
@@ -34,7 +34,7 @@ void *plan(Tensor x_out,
            const Tensor &sin,
            const Tensor &cos,
            infinicore::nn::RoPE::Algo algo) {
-    INFINICORE_ASSERT(x_out->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(x_out->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(x_out, x, pos, sin, cos);
     return new PlannedMeta{
         TensorMeta(x_out), TensorMeta(x), TensorMeta(pos), TensorMeta(sin), TensorMeta(cos),
@@ -64,9 +64,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    RoPE::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    RoPE::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    RoPE::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(RoPE::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(RoPE::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(RoPE::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 } // namespace infinicore::op::rope_impl::infiniops

--- a/src/infinicore/ops/sigmoid/sigmoid_infiniops.cc
+++ b/src/infinicore/ops/sigmoid/sigmoid_infiniops.cc
@@ -18,7 +18,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor output, const Tensor &input) {
-    INFINICORE_ASSERT(output->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(output->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input);
 
     return new PlannedMeta{
@@ -48,9 +48,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    Sigmoid::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    Sigmoid::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    Sigmoid::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(Sigmoid::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(Sigmoid::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(Sigmoid::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 

--- a/src/infinicore/ops/silu/silu_infiniops.cc
+++ b/src/infinicore/ops/silu/silu_infiniops.cc
@@ -11,7 +11,7 @@ namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 
 void calculate(Tensor output, Tensor input) {
-    INFINICORE_ASSERT(output->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(output->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input);
 
     infini::ops::Handle handle;
@@ -30,7 +30,7 @@ void calculate(Tensor output, Tensor input) {
 } // namespace
 
 static bool registered = []() {
-    Silu::dispatcher().registerDevice(Device::Type::NVIDIA, &calculate);
+    ::infinicore::op::infiniops::registerSupportedDevices(Silu::dispatcher(), &calculate);
     return true;
 }();
 

--- a/src/infinicore/ops/silu_and_mul/silu_and_mul_infiniops.cc
+++ b/src/infinicore/ops/silu_and_mul/silu_and_mul_infiniops.cc
@@ -15,7 +15,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor output, const Tensor &input) {
-    INFINICORE_ASSERT(output->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(output->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input);
     return new PlannedMeta{TensorMeta(output), TensorMeta(input), graph::GraphTensor(output), graph::GraphTensor(input)};
 }
@@ -35,9 +35,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    SiluAndMul::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    SiluAndMul::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    SiluAndMul::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(SiluAndMul::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(SiluAndMul::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(SiluAndMul::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 } // namespace infinicore::op::silu_and_mul_impl::infiniops

--- a/src/infinicore/ops/softmax/softmax_infiniops.cc
+++ b/src/infinicore/ops/softmax/softmax_infiniops.cc
@@ -13,7 +13,7 @@ namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 
 void calculate(Tensor output, Tensor input, int axis) {
-    INFINICORE_ASSERT(output->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(output->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input);
 
     infini::ops::Handle handle;
@@ -34,7 +34,7 @@ void calculate(Tensor output, Tensor input, int axis) {
 } // namespace
 
 static bool registered = []() {
-    Softmax::dispatcher().registerDevice(Device::Type::NVIDIA, &calculate);
+    ::infinicore::op::infiniops::registerSupportedDevices(Softmax::dispatcher(), &calculate);
     return true;
 }();
 

--- a/src/infinicore/ops/swiglu/swiglu_infiniops.cc
+++ b/src/infinicore/ops/swiglu/swiglu_infiniops.cc
@@ -18,7 +18,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor c, const Tensor &a, const Tensor &b) {
-    INFINICORE_ASSERT(c->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(c->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(c, a, b);
 
     return new PlannedMeta{
@@ -51,9 +51,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    SwiGLU::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    SwiGLU::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    SwiGLU::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(SwiGLU::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(SwiGLU::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(SwiGLU::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 

--- a/src/infinicore/ops/topksoftmax/topksoftmax_infiniops.cc
+++ b/src/infinicore/ops/topksoftmax/topksoftmax_infiniops.cc
@@ -17,7 +17,7 @@ struct PlannedMeta {
 } // namespace
 
 void *plan(Tensor values, Tensor indices, const Tensor &x, const size_t topk, const int norm) {
-    INFINICORE_ASSERT(values->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(values->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(values, indices, x);
     return new PlannedMeta{TensorMeta(values), TensorMeta(indices), TensorMeta(x), graph::GraphTensor(values), graph::GraphTensor(indices), graph::GraphTensor(x), topk, norm};
 }
@@ -43,9 +43,9 @@ void cleanup(void **planned_meta_ptr) {
 }
 
 static bool registered = []() {
-    Topksoftmax::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
-    Topksoftmax::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
-    Topksoftmax::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    ::infinicore::op::infiniops::registerSupportedDevices(Topksoftmax::plan_dispatcher(), &plan);
+    ::infinicore::op::infiniops::registerSupportedDevices(Topksoftmax::run_dispatcher(), &run);
+    ::infinicore::op::infiniops::registerSupportedDevices(Topksoftmax::cleanup_dispatcher(), &cleanup);
     return true;
 }();
 } // namespace infinicore::op::topksoftmax_impl::infiniops

--- a/xmake.lua
+++ b/xmake.lua
@@ -237,6 +237,9 @@ option_end()
 
 if has_config("aten") then
     add_defines("ENABLE_ATEN")
+    if has_config("iluvatar-gpu") then
+        add_defines("_GLIBCXX_USE_CXX11_ABI=0")
+    end
     if get_config("flash-attn") and get_config("flash-attn") ~= ""
        and (has_config("nv-gpu") or has_config("metax-gpu") or has_config("qy-gpu")) then
         add_defines("ENABLE_FLASH_ATTN")
@@ -317,6 +320,48 @@ end
 
 local infiniops_external_built = false
 
+local function filter_infiniops_ops_for_backend(infiniops_ops)
+    if not infiniops_ops or #infiniops_ops == 0 then
+        return infiniops_ops
+    end
+    if has_config("nv-gpu") then
+        return infiniops_ops
+    end
+
+    local skipped_ops = {
+        paged_attention_infinilm = true,
+        paged_attention_prefill_infinilm = true
+    }
+    local filtered = {}
+    for _, op in ipairs(infiniops_ops:split("[,;]")) do
+        op = op:trim()
+        if #op > 0 and not skipped_ops[op] then
+            table.insert(filtered, op)
+        end
+    end
+    return table.concat(filtered, ",")
+end
+
+local function get_infiniops_backend_cmake_arg()
+    local enabled = {}
+    local function add_backend(config, cmake_arg)
+        if has_config(config) then
+            table.insert(enabled, cmake_arg)
+        end
+    end
+    add_backend("nv-gpu", "-DWITH_NVIDIA=ON")
+    add_backend("metax-gpu", "-DWITH_METAX=ON")
+    add_backend("iluvatar-gpu", "-DWITH_ILUVATAR=ON")
+    add_backend("moore-gpu", "-DWITH_MOORE=ON")
+    if #enabled == 0 then
+        raise("InfiniOps integration requires one of --nv-gpu, --metax-gpu, --iluvatar-gpu, or --moore-gpu")
+    end
+    if #enabled > 1 then
+        raise("InfiniOps can build only one GPU backend at a time")
+    end
+    return enabled[1]
+end
+
 local function build_infiniops_external(xmake_os)
     if not has_config("infiniops") or infiniops_external_built then
         return
@@ -328,12 +373,17 @@ local function build_infiniops_external(xmake_os)
     local cmake_config_args = {
         "-S", infiniops_root,
         "-B", infiniops_builddir,
-        "-DWITH_NVIDIA=ON",
+        "-DWITH_CPU=ON",
+        get_infiniops_backend_cmake_arg(),
         "-DGENERATE_OPERATOR_CALL_INSTANTIATIONS=ON",
         "-DGENERATE_PYTHON_BINDINGS=OFF",
         "-DCMAKE_BUILD_TYPE=Release"
     }
-    local infiniops_ops = os.getenv("INFINI_OPS_OPS")
+    if has_config("iluvatar-gpu") and has_config("aten") then
+        table.insert(cmake_config_args, "-DTORCH_CXX11_ABI=0")
+        table.insert(cmake_config_args, "-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
+    end
+    local infiniops_ops = filter_infiniops_ops_for_backend(os.getenv("INFINI_OPS_OPS"))
     if infiniops_ops and #infiniops_ops > 0 then
         table.insert(cmake_config_args, "-DINFINI_OPS_OPS=" .. infiniops_ops)
     end
@@ -363,6 +413,7 @@ local function build_infiniops_external(xmake_os)
         local private_infinirt = path.join(INFINI_ROOT, "lib", private_soname)
         xmake_os.cp(standalone_infinirt, private_infinirt)
         xmake_os.execv("patchelf", {"--set-soname", private_soname, private_infinirt})
+        xmake_os.execv("patchelf", {"--replace-needed", standalone_infinirt, private_soname, infiniops_lib})
         xmake_os.execv("patchelf", {"--replace-needed", "libinfinirt.so", private_soname, infiniops_lib})
     end
     infiniops_external_built = true
@@ -582,6 +633,17 @@ target("infinicore_cpp_api")
     local INFINI_ROOT = os.getenv("INFINI_ROOT") or (os.getenv(is_host("windows") and "HOMEPATH" or "HOME") .. "/.infini")
 
     add_includedirs("include")
+    if has_config("metax-gpu") and has_config("use-mc") and has_config("aten") then
+        local maca_root = os.getenv("MACA_PATH") or os.getenv("MACA_HOME") or os.getenv("MACA_ROOT") or "/opt/maca"
+        add_includedirs(maca_root .. "/include")
+        add_includedirs(maca_root .. "/tools/cu-bridge/include")
+        for _, include_dir in ipairs(os.dirs(maca_root .. "/include/*")) do
+            add_includedirs(include_dir)
+        end
+        add_cxflags("-include", "climits")
+        add_cxxflags("-includeclimits", {force = true})
+        add_defines("CHAR_BIT=8", "INT_MIN=(-2147483647 - 1)", "INT_MAX=2147483647", "UINT_MAX=4294967295U")
+    end
     add_includedirs(INFINI_ROOT.."/include", { public = true })
     if has_config("nv-gpu") then
         local cuda_root = os.getenv("CUDA_HOME") or os.getenv("CUDA_PATH") or get_config("cuda") or "/usr/local/cuda"
@@ -592,9 +654,7 @@ target("infinicore_cpp_api")
         if not os.isdir(infiniops_root) then
             raise("InfiniOps root not found: " .. infiniops_root)
         end
-        if not has_config("nv-gpu") then
-            raise("InfiniOps integration currently has adapters only for NVIDIA")
-        end
+        get_infiniops_backend_cmake_arg()
         local infinirt_root = get_standalone_infinirt_root()
         if infinirt_root and infinirt_root ~= "" then
             add_includedirs(infinirt_root .. "/include")
@@ -797,6 +857,10 @@ target("infinicore_cpp_api")
     add_files("src/infinicore/nn/*.cc")
     add_files("src/infinicore/ops/*/*.cc")
     add_files("src/infinicore/ops/*/*/*.cc")
+    if has_config("infiniops") and not has_config("nv-gpu") then
+        remove_files("src/infinicore/ops/paged_attention/paged_attention_infiniops.cc")
+        remove_files("src/infinicore/ops/paged_attention_prefill/paged_attention_prefill_infiniops.cc")
+    end
     if has_config("mutual-awareness") then
         add_files("src/infinicore/analyzer/*.cc")
     end
@@ -865,6 +929,7 @@ target("_infinicore")
                 local private_infinirt = path.join(INFINI_ROOT, "lib", private_soname)
                 os.cp(standalone_infinirt, private_infinirt)
                 os.execv("patchelf", {"--set-soname", private_soname, private_infinirt})
+                os.execv("patchelf", {"--replace-needed", standalone_infinirt, private_soname, infiniops_lib})
                 os.execv("patchelf", {"--replace-needed", "libinfinirt.so", private_soname, infiniops_lib})
             end
             os.mkdir(path.join(INFINI_ROOT, "lib"))


### PR DESCRIPTION
## Summary

- extend the InfiniOps direct-call adapters from NVIDIA-only registration to NVIDIA, MetaX, Moore, and Iluvatar
- build the embedded InfiniOps submodule with the selected GPU backend and pass standalone InfiniRT include/lib information through to InfiniCore consumers
- skip InfiniOps paged-attention direct-call sources on non-NVIDIA backends so those platforms keep using their existing implementations
- update the InfiniOps and InfiniRT submodule pointers to versions that include the standalone InfiniRT integration

## Root Cause

After InfiniOps moved to standalone InfiniRT, InfiniCore consumers needed the standalone InfiniRT public headers and runtime library on the same build/runtime path as installed InfiniOps. The previous InfiniCore integration also registered the new InfiniOps adapters only for NVIDIA, so MetaX, Moore, and Iluvatar could not exercise those direct-call wrappers.

## Validation

- NVIDIA path was previously validated with InfiniLM inference after InfiniOps standalone InfiniRT landed.
- Moore: built InfiniRT, InfiniOps, InfiniCore, `_infinicore`, installed InfiniLM, and ran `examples/test_infer.py --device moore --model=/data-aisoft/mechdancer/models/Qwen3-0.6B/` successfully.
- Iluvatar: built with old C++ ABI for InfiniCore/InfiniOps/InfiniLM and ran `examples/test_infer.py --device iluvatar --model=/data-aisoft/mechdancer/models/Qwen3-0.6B/` successfully.
- MetaX: built with `--metax-gpu=true --use-mc=true --aten=true --infiniops=true`, installed InfiniCore and InfiniLM, and ran `examples/test_infer.py --device metax --model=/data-aisoft/mechdancer/models/Qwen3-0.6B/` successfully.
- MetaX inference output included:

```text
===Response===
<think>
Okay, the user asked, "How are you?" ...
</think>

I'm here to help! How can I assist you today? I'm available 24/7 for any questions or support. Let me know what you need! 😊<|im_end|>

total_time: 32265.22 ms
```

## InfiniOps Symbol Check

On MetaX, `ldd` resolves `libinfiniops.so`, `libinfiniops_infinirt.so`, and `libinfinirt.so` from the same installed prefix. `nm -D libinfinicore_cpp_api.so | c++filt` shows undefined references such as:

```text
U void infini::ops::Operator<infini::ops::Add, (infini::rt::Device::Type)10, 0ul>::Call<...>
U void infini::ops::Operator<infini::ops::Gemm, (infini::rt::Device::Type)10, 0ul>::Call<...>
U void infini::ops::Operator<infini::ops::RmsNorm, (infini::rt::Device::Type)10, 0ul>::Call<...>
```

and `nm -D libinfiniops.so | c++filt` provides the matching weak exported symbols, confirming the direct-call operators are resolved from InfiniOps rather than instantiated in the InfiniCore consumer.

Fixes #1320.
