### PR TITLE
fix graph on ascend

### DIFF
--- a/src/infinicore/graph/graph.cc
+++ b/src/infinicore/graph/graph.cc
@@ -37,7 +37,7 @@ struct Graph::DeviceGraph {
     infinirtGraphNode_t node;
     std::vector<char> log_buffer;
 
-    DeviceGraph() {
+    DeviceGraph() : graph(nullptr), exec(nullptr), node(nullptr) {
         log_buffer.resize(4 * 1024);
     }
 

--- a/src/infinirt/ascend/infinirt_ascend.cc
+++ b/src/infinirt/ascend/infinirt_ascend.cc
@@ -162,15 +162,34 @@ infiniStatus_t freeAsync(void *ptr, infinirtStream_t stream) {
 }
 
 infiniStatus_t streamBeginCapture(infinirtStream_t stream, infinirtStreamCaptureMode_t mode) {
-    return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    aclmdlRICaptureMode acl_mode;
+    switch (mode) {
+    case INFINIRT_STREAM_CAPTURE_MODE_GLOBAL:
+        acl_mode = ACL_MODEL_RI_CAPTURE_MODE_GLOBAL;
+        break;
+    case INFINIRT_STREAM_CAPTURE_MODE_THREAD_LOCAL:
+        acl_mode = ACL_MODEL_RI_CAPTURE_MODE_THREAD_LOCAL;
+        break;
+    case INFINIRT_STREAM_CAPTURE_MODE_RELAXED:
+        acl_mode = ACL_MODEL_RI_CAPTURE_MODE_RELAXED;
+        break;
+    default:
+        return INFINI_STATUS_BAD_PARAM;
+    }
+    CHECK_ACLRT(aclmdlRICaptureBegin((aclrtStream)stream, acl_mode));
+    return INFINI_STATUS_SUCCESS;
 }
 
 infiniStatus_t streamEndCapture(infinirtStream_t stream, infinirtGraph_t *graph_ptr) {
-    return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    aclmdlRI modelRI = nullptr;
+    CHECK_ACLRT(aclmdlRICaptureEnd((aclrtStream)stream, &modelRI));
+    *graph_ptr = (infinirtGraph_t)modelRI;
+    return INFINI_STATUS_SUCCESS;
 }
 
 infiniStatus_t graphDestroy(infinirtGraph_t graph) {
-    return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    (void)graph;
+    return INFINI_STATUS_SUCCESS;
 }
 
 infiniStatus_t graphInstantiate(
@@ -179,15 +198,21 @@ infiniStatus_t graphInstantiate(
     infinirtGraphNode_t *node_ptr,
     char *log_buffer,
     size_t buffer_size) {
-    return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    *graph_exec_ptr = (infinirtGraphExec_t)graph;
+    if (node_ptr) {
+        *node_ptr = nullptr;
+    }
+    return INFINI_STATUS_SUCCESS;
 }
 
 infiniStatus_t graphExecDestroy(infinirtGraphExec_t graph_exec) {
-    return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    CHECK_ACLRT(aclmdlRIDestroy((aclmdlRI)graph_exec));
+    return INFINI_STATUS_SUCCESS;
 }
 
 infiniStatus_t graphLuanch(infinirtGraphExec_t graph_exec, infinirtStream_t stream) {
-    return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    CHECK_ACLRT(aclmdlRIExecuteAsync((aclmdlRI)graph_exec, (aclrtStream)stream));
+    return INFINI_STATUS_SUCCESS;
 }
 
 infiniStatus_t getMemInfo(int device_id, size_t *free_bytes, size_t *total_bytes) {


### PR DESCRIPTION
基于 ACL ModelRI 在昇腾 Ascend 上实现graph特性。

修改内容：
1、/src/infinirt/ascend/infinirt_ascend.cc：将原先返回 DEVICE_TYPE_NOT_SUPPORTED 的桩函数替换为基于 aclmdlRICaptureBegin/aclmdlRICaptureEnd/aclmdlRIDestroy/aclmdlRIExecuteAsync 的完整实现； 2、/src/infinicore/graph/ascend/graph.cc：DeviceGraph 构造函数增加 graph/exec/node 的 nullptr 显式初始化，防止未初始化指针导致的未定义行为。

现状：
1、当前实现可通过/test/infinicore/graph/attention.py用例测试：
<img width="471" height="284" alt="d45fb2f2-ac7d-44fe-b671-9c8aed8ef8a3" src="https://github.com/user-attachments/assets/dc1693ea-2f8a-4d12-821c-507f389fd3f9" />
2、与static attn不兼容，不能单独开启用于性能测试，需要依赖paged-attn或者flash-attn。与当前未优化版本的paged-attn一同开启会发生OOM，无法使用，待实现flash-attn：
<img width="2286" height="420" alt="28aa1386-c45f-4f29-92e9-2f926e73e57a" src="https://github.com/user-attachments/assets/423b434e-98cb-4ca8-a5e6-1e1f56521231" />