### PR TITLE
perf(metax): vectorize elementwise kernel for contiguous aligned tensors

### DIFF
--- a/src/infiniop/elementwise/metax/elementwise_metax.h
+++ b/src/infiniop/elementwise/metax/elementwise_metax.h
@@ -5,6 +5,7 @@
 #include "../../devices/metax/metax_common.h"
 #include "../../devices/metax/metax_kernel_common.h"
 #include "elementwise_metax_api.h"
+#include <cstdint>
 
 namespace op::elementwise::metax {
 template <typename T>
@@ -12,9 +13,90 @@ __device__ __forceinline__ const T *typedInputPtr(const void *ptr) {
     return reinterpret_cast<const T *>(ptr);
 }
 
+// Generic aligned N-element pack used for vectorized load/store.
+template <typename T, int N>
+struct alignas(sizeof(T) * N) Pack {
+    T val[N];
+};
+
+// Per-dtype vectorization info. Only floating-point types are enabled.
+// Integer/bool/fp8 types keep using the scalar fallback automatically.
+template <typename T>
+struct VecInfo {
+    static constexpr bool enabled = false;
+};
+
+template <>
+struct VecInfo<float> {
+    static constexpr bool enabled = true;
+    static constexpr int pack_size = 4;
+    using Type = Pack<float, pack_size>;
+};
+
+template <>
+struct VecInfo<half> {
+    static constexpr bool enabled = true;
+    static constexpr int pack_size = 8;
+    using Type = Pack<half, pack_size>;
+};
+
+template <>
+struct VecInfo<cuda_bfloat16> {
+    static constexpr bool enabled = true;
+    static constexpr int pack_size = 8;
+    using Type = Pack<cuda_bfloat16, pack_size>;
+};
+
+template <>
+struct VecInfo<double> {
+    static constexpr bool enabled = true;
+    static constexpr int pack_size = 2;
+    using Type = Pack<double, pack_size>;
+};
+
+template <typename Tdata, typename VecT, size_t N>
+__device__ __forceinline__ void loadInputVectors(VecT *in_vecs,
+                                                 const Tdata *const *typed_inputs,
+                                                 size_t base) {
+#pragma unroll
+    for (size_t i = 0; i < N; ++i) {
+        in_vecs[i] = *reinterpret_cast<const VecT *>(typed_inputs[i] + base);
+    }
+}
+
 __device__ __forceinline__ size_t getOutputIndex(size_t idx, bool is_contiguous, size_t ndim,
                                                  const size_t *shape, const ptrdiff_t *strides) {
     return is_contiguous ? idx : device::metax::indexToOffset(idx, ndim, shape, strides);
+}
+
+template <typename Tdata, size_t N>
+bool canUseVecPath(const op::elementwise::ElementwiseInfo &info,
+                   const void *output,
+                   const std::vector<const void *> &inputs) {
+    if constexpr (!VecInfo<Tdata>::enabled) {
+        return false;
+    }
+    if (!info.isOutputContiguous()) {
+        return false;
+    }
+    const bool *contiguous = info.getInputContiguous();
+    const bool *broadcasted = info.getInputBroadcasted();
+    for (size_t i = 0; i < N; ++i) {
+        if (!contiguous[i] || broadcasted[i]) {
+            return false;
+        }
+    }
+    // Require 16-byte alignment of output and every input pointer.
+    constexpr std::uintptr_t mask = 0xF;
+    if ((reinterpret_cast<std::uintptr_t>(output) & mask) != 0) {
+        return false;
+    }
+    for (const void *p : inputs) {
+        if ((reinterpret_cast<std::uintptr_t>(p) & mask) != 0) {
+            return false;
+        }
+    }
+    return true;
 }
 
 struct InputIndexer {
@@ -36,6 +118,47 @@ struct InputIndexer {
 template <typename F, size_t... Is>
 __device__ __forceinline__ void unpackInputsAndApply(F &&f, std::index_sequence<Is...>) {
     f(std::integral_constant<size_t, Is>{}...);
+}
+
+template <size_t N, typename Op, typename Tdata, typename VecT, int V, typename... Args>
+INFINIOP_METAX_KERNEL elementwiseVecKernel(
+    size_t output_size,
+    Tdata *__restrict__ output,
+    const void *const *__restrict__ inputs,
+    Args... args) {
+
+    const Tdata *const *typed_inputs = reinterpret_cast<const Tdata *const *>(inputs);
+    const size_t num_packs = output_size / V;
+    const size_t tail_start = num_packs * V;
+    const size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t stride = blockDim.x * gridDim.x;
+
+    // Vectorized main loop over 16-byte packs
+    for (size_t pack_idx = tid; pack_idx < num_packs; pack_idx += stride) {
+        const size_t base = pack_idx * V;
+        VecT in_vecs[N];
+        loadInputVectors<Tdata, VecT, N>(in_vecs, typed_inputs, base);
+
+        VecT out_vec;
+#pragma unroll
+        for (int k = 0; k < V; ++k) {
+            unpackInputsAndApply(
+                [&](auto... Is) {
+                    out_vec.val[k] = Op{}(in_vecs[Is.value].val[k]..., std::forward<Args>(args)...);
+                },
+                std::make_index_sequence<N>{});
+        }
+        *reinterpret_cast<VecT *>(output + base) = out_vec;
+    }
+
+    // Scalar tail for remaining elements
+    for (size_t idx = tail_start + tid; idx < output_size; idx += stride) {
+        unpackInputsAndApply(
+            [&](auto... Is) {
+                output[idx] = Op{}(typed_inputs[Is.value][idx]..., std::forward<Args>(args)...);
+            },
+            std::make_index_sequence<N>{});
+    }
 }
 
 template <size_t N, typename Op, typename Tdata, typename... Args>
@@ -112,6 +235,16 @@ struct DeviceImpl::Opaque {
                                  const std::vector<const void *> &inputs,
                                  hcStream_t stream,
                                  Args &&...args) {
+        if constexpr (VecInfo<Tdata>::enabled) {
+            if (canUseVecPath<Tdata, N>(info, output, inputs)) {
+                return launchElementwiseVecKernel<BLOCK_SIZE, N, Op, Tdata,
+                                                  typename VecInfo<Tdata>::Type,
+                                                  VecInfo<Tdata>::pack_size>(
+                    info, workspace,
+                    reinterpret_cast<Tdata *>(output), inputs, stream,
+                    std::forward<Args>(args)...);
+            }
+        }
         return launchElementwiseKernel<BLOCK_SIZE, N>(
             info, workspace,
             reinterpret_cast<Tdata *>(output), inputs,
@@ -136,6 +269,41 @@ struct DeviceImpl::Opaque {
     }
 
 private:
+    template <uint32_t BLOCK_SIZE, size_t N, typename Op, typename Tdata, typename VecT, int V, typename... Args>
+    infiniStatus_t launchElementwiseVecKernel(
+        const op::elementwise::ElementwiseInfo &info,
+        void *workspace,
+        Tdata *output,
+        const std::vector<const void *> &inputs,
+        hcStream_t stream,
+        Args &&...args) {
+
+        const auto output_size = info.getOutputSize();
+        if (output_size == 0) {
+            return INFINI_STATUS_SUCCESS;
+        }
+
+        CHECK_METAX(hcMemcpyAsync(workspace, inputs.data(), N * sizeof(*inputs.data()),
+                                  hcMemcpyHostToDevice, stream));
+        const void **d_inputs_arr = reinterpret_cast<const void **>(workspace);
+
+        dim3 blockDims(std::min(BLOCK_SIZE, static_cast<uint32_t>(internal->maxThreadsPerBlock())));
+        const size_t num_packs = output_size / V;
+        const size_t tail_size = output_size - num_packs * V;
+        const size_t grid_work = num_packs > 0 ? num_packs : tail_size;
+        dim3 gridDims(std::min(static_cast<uint32_t>(CEIL_DIV(grid_work, blockDims.x)),
+                               static_cast<uint32_t>(internal->gridSizeX())));
+        if (gridDims.x == 0) {
+            gridDims.x = 1;
+        }
+
+        elementwiseVecKernel<N, Op, Tdata, VecT, V, Args...>
+            <<<gridDims, blockDims, 0, stream>>>(
+                output_size, output, d_inputs_arr, std::forward<Args>(args)...);
+
+        return INFINI_STATUS_SUCCESS;
+    }
+
     template <size_t N>
     infiniStatus_t infoToDevice(
         const op::elementwise::ElementwiseInfo &info,


### PR DESCRIPTION
# MetaX Elementwise Vectorization Performance Report

## Environment

- GPU: MetaX C500 64GB
- MACA: 3.3.0.15
- Repository: InfiniCore
- File changed: `src/infiniop/elementwise/metax/elementwise_metax.h`
- Benchmark script: `vec_bench.py` (silu, synchronized timing)

## What changed

Added a 16-byte contiguous vector fast path to the shared MetaX elementwise kernel. When output and all inputs are contiguous, aligned, non-broadcasted, and use the same floating-point dtype, the kernel loads/stores `float4` / `Pack<half,8>` / `Pack<cuda_bfloat16,8>` / `Pack<double,2>` packs and applies the existing scalar `Op{}` per component. Strided, broadcasted, unaligned, integer, or mixed-dtype cases fall back to the original scalar kernel unchanged.

## Correctness

Regression tests passed on Metax:

- silu: PASS
- add: PASS
- mul: PASS
- reciprocal: PASS
- gelu: PASS
- swiglu: PASS
- clip: PASS

`tanh.py` failed with `INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED` because the `tanh/operator.cc` Metax registration is commented out on this branch; unrelated to this change. `hardtanh.py` has a pre-existing GPU crash on the scalar kernel; also unrelated.

## Performance (silu)

### Scalar baseline (before vectorization)

| shape | dtype | lib_ms | Gelem/s | GB/s |
|-------|-------|--------|---------|------|
| (4096, 4096) | F16 | 0.399 | 42.05 | 168.2 |
| (4096, 4096) | F32 | 0.403 | 41.66 | 333.3 |
| (4096, 4096) | BF16 | 0.371 | 45.25 | 181.0 |
| (8192, 8192) | F16 | 1.156 | 58.05 | 232.2 |
| (8192, 8192) | F32 | 1.222 | 54.93 | 439.4 |
| (8192, 8192) | BF16 | 1.150 | 58.37 | 233.5 |
| (16384, 16384) | F16 | 4.208 | 63.79 | 255.1 |
| (16384, 16384) | F32 | 4.555 | 58.94 | 471.5 |
| (16384, 16384) | BF16 | 4.210 | 63.77 | 255.1 |

### Vectorized (after)

| shape | dtype | lib_ms | Gelem/s | GB/s | speedup |
|-------|-------|--------|---------|------|---------|
| (4096, 4096) | F16 | 0.146 | 114.66 | 458.6 | 2.73x |
| (4096, 4096) | F32 | 0.151 | 110.76 | 886.1 | 2.66x |
| (4096, 4096) | BF16 | 0.143 | 117.18 | 468.7 | 2.59x |
| (8192, 8192) | F16 | 0.352 | 190.87 | 763.5 | 3.29x |
| (8192, 8192) | F32 | 0.458 | 146.60 | 1172.8 | 2.67x |
| (8192, 8192) | BF16 | 0.405 | 165.53 | 662.1 | 2.84x |
| (16384, 16384) | F16 | 1.100 | 243.98 | 975.9 | 3.82x |
| (16384, 16384) | F32 | 1.516 | 177.01 | 1416.1 | 3.00x |
| (16384, 16384) | BF16 | 1.246 | 215.44 | 861.8 | 3.38x |

### Observations

- Large contiguous tensors show **3-4x speedup** over the scalar kernel.
- F32 effective bandwidth reaches ~1.4 TB/s on the C500, indicating the vector path successfully saturates a large fraction of device memory bandwidth.
- Smaller tensors (4Kx4K) show ~2.6-2.7x; fixed kernel-launch overhead reduces the relative gain.
- All fallback cases (strided, broadcast, integer dtypes, mixed dtype) continue to use the original scalar path and were verified to pass correctness tests.

## Known limitations

- Only same-dtype floating-point elementwise ops are vectorized. Integer/bool/fp8 and mixed-dtype ops use the scalar fallback.
- Input and output pointers must be 16-byte aligned. PyTorch CUDA allocations typically satisfy this for tensors created with the default allocator.
- The MACA compiler emits lld warnings about `#pragma unroll` being unable to unroll some loops; these are non-fatal and do not affect correctness or the measured speedup.

## Next steps

- Apply the same pattern to the NVIDIA/CUDA elementwise backend for parity.
- Extend to integer types (`int32_t`, `int64_t`) with 16-byte packs once validated.
- Investigate whether compute-bound operators (e.g. `gelu`, `swiglu`) can additionally benefit from vector ALU intrinsics (`half2`).
