### PR TITLE
fix: support head dim 256 in paged attention

### DIFF
--- a/src/infiniop/ops/paged_attention/cuda/kernel_v2.cuh
+++ b/src/infiniop/ops/paged_attention/cuda/kernel_v2.cuh
@@ -157,7 +157,7 @@ __device__ void flashAttentionDecodeWarpKernel(
     const int head_idx = blockIdx.x;
     const int lane = threadIdx.x;
     constexpr int kWarpSize = 32;
-    static_assert(HEAD_SIZE == 64 || HEAD_SIZE == 128 || HEAD_SIZE == 192 || HEAD_SIZE == 576, "Only head_size 64/128/192/576 supported in v0.4.");
+    static_assert(HEAD_SIZE == 64 || HEAD_SIZE == 128 || HEAD_SIZE == 192 || HEAD_SIZE == 256 || HEAD_SIZE == 576, "Only head_size 64/128/192/256/576 supported in v0.4.");
     static_assert(HEAD_SIZE % kWarpSize == 0, "HEAD_SIZE must be divisible by 32.");
     constexpr int DIMS_PER_THREAD = HEAD_SIZE / kWarpSize;
 
@@ -366,7 +366,7 @@ __device__ void flashAttentionDecodeSplitKvWarpKernel(
     const int split_idx = static_cast<int>(blockIdx.z);
     const int lane = threadIdx.x;
     constexpr int kWarpSize = 32;
-    static_assert(HEAD_SIZE == 64 || HEAD_SIZE == 128 || HEAD_SIZE == 192 || HEAD_SIZE == 576, "Only head_size 64/128/192/576 supported in v0.4.");
+    static_assert(HEAD_SIZE == 64 || HEAD_SIZE == 128 || HEAD_SIZE == 192 || HEAD_SIZE == 256 || HEAD_SIZE == 576, "Only head_size 64/128/192/256/576 supported in v0.4.");
     static_assert(HEAD_SIZE % kWarpSize == 0, "HEAD_SIZE must be divisible by 32.");
     constexpr int DIMS_PER_THREAD = HEAD_SIZE / kWarpSize;
 
@@ -646,7 +646,7 @@ __device__ void flashAttentionDecodeSplitKvCtaKernel(
     static_assert(TOKENS_PER_TILE > 0 && TOKENS_PER_TILE <= 16, "TOKENS_PER_TILE should stay small.");
     constexpr int NUM_WARPS = CTA_THREADS / kWarpSize;
 
-    static_assert(HEAD_SIZE == 64 || HEAD_SIZE == 128 || HEAD_SIZE == 192 || HEAD_SIZE == 576, "Only head_size 64/128/192/576 supported in v0.4.");
+    static_assert(HEAD_SIZE == 64 || HEAD_SIZE == 128 || HEAD_SIZE == 192 || HEAD_SIZE == 256 || HEAD_SIZE == 576, "Only head_size 64/128/192/256/576 supported in v0.4.");
     static_assert(HEAD_SIZE % CTA_THREADS == 0, "HEAD_SIZE must be divisible by CTA_THREADS.");
     constexpr int kPack = HEAD_SIZE / CTA_THREADS; // 2 (64@32t, 128@64t) or 4 (128@32t)
     static_assert(kPack == 2 || kPack == 4, "v0.4 split-kv CTA kernel supports kPack=2/4 only.");
@@ -1096,7 +1096,7 @@ __device__ void flashAttentionDecodeCtaPipelinedKernel(
     ptrdiff_t o_stride) {
 
     constexpr int kWarpSize = 32;
-    static_assert(HEAD_SIZE == 64 || HEAD_SIZE == 128 || HEAD_SIZE == 192 || HEAD_SIZE == 576, "Only head_size 64/128/192/576 supported in v0.4.");
+    static_assert(HEAD_SIZE == 64 || HEAD_SIZE == 128 || HEAD_SIZE == 192 || HEAD_SIZE == 256 || HEAD_SIZE == 576, "Only head_size 64/128/192/256/576 supported in v0.4.");
     static_assert(HEAD_SIZE % kWarpSize == 0, "HEAD_SIZE must be divisible by 32.");
     constexpr int NUM_WARPS = HEAD_SIZE / kWarpSize;
 

--- a/src/infiniop/ops/paged_attention/info.h
+++ b/src/infiniop/ops/paged_attention/info.h
@@ -124,7 +124,7 @@ public:
         //     printf("paged block size %zu\n", page_block_size);
         //     return INFINI_STATUS_BAD_TENSOR_SHAPE;
         // }
-        if (head_size != 64 && head_size != 128 && head_size != 192 && head_size != 576) {
+        if (head_size != 64 && head_size != 128 && head_size != 192 && head_size != 256 && head_size != 576) {
             // First build only targets common FA2 head dims plus DeepSeek MLA latent dim.
             return INFINI_STATUS_BAD_TENSOR_SHAPE;
         }

--- a/src/infiniop/ops/paged_attention/metax/paged_attention_hd256.maca
+++ b/src/infiniop/ops/paged_attention/metax/paged_attention_hd256.maca
@@ -1,0 +1,259 @@
+#ifdef ENABLE_METAX_MC_API
+#include <mc_runtime.h>
+#else
+#include <hc_runtime.h>
+#endif
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+#include "../../../devices/metax/metax_common.h"
+#include "../../../devices/metax/metax_kernel_common.h"
+#include "../cuda/kernel_v2.cuh"
+
+namespace op::paged_attention::metax {
+
+template <typename Tindex, typename Tdata>
+INFINIOP_METAX_KERNEL flashAttentionDecodeHd256Warp(
+    Tdata *out,
+    const Tdata *q,
+    const Tdata *k_cache,
+    const Tdata *v_cache,
+    const Tindex *block_tables,
+    const Tindex *cache_lens,
+    const float *alibi_slopes,
+    size_t num_kv_heads,
+    float scale,
+    size_t max_num_blocks_per_seq,
+    size_t page_block_size,
+    ptrdiff_t q_stride,
+    ptrdiff_t k_batch_stride,
+    ptrdiff_t k_row_stride,
+    ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride,
+    ptrdiff_t v_row_stride,
+    ptrdiff_t v_head_stride,
+    ptrdiff_t o_stride) {
+    op::paged_attention::cuda::flashAttentionDecodeWarpKernel<Tindex, Tdata, 256>(
+        out, q, k_cache, v_cache, block_tables, cache_lens, alibi_slopes,
+        num_kv_heads, scale, max_num_blocks_per_seq, page_block_size, q_stride,
+        k_batch_stride, k_row_stride, k_head_stride, v_batch_stride, v_row_stride,
+        v_head_stride, o_stride);
+}
+
+template <typename Tindex, typename Tdata>
+INFINIOP_METAX_KERNEL flashAttentionDecodeHd256SplitKv(
+    float *partial_acc,
+    float *partial_m,
+    float *partial_l,
+    const Tdata *q,
+    const Tdata *k_cache,
+    const Tdata *v_cache,
+    const Tindex *block_tables,
+    const Tindex *cache_lens,
+    const float *alibi_slopes,
+    size_t num_kv_heads,
+    float scale,
+    size_t max_num_blocks_per_seq,
+    size_t page_block_size,
+    ptrdiff_t q_stride,
+    ptrdiff_t k_batch_stride,
+    ptrdiff_t k_row_stride,
+    ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride,
+    ptrdiff_t v_row_stride,
+    ptrdiff_t v_head_stride,
+    int num_splits) {
+    op::paged_attention::cuda::flashAttentionDecodeSplitKvWarpKernel<Tindex, Tdata, 256>(
+        partial_acc, partial_m, partial_l,
+        q, k_cache, v_cache, block_tables, cache_lens, alibi_slopes,
+        num_kv_heads, scale, max_num_blocks_per_seq, page_block_size, q_stride,
+        k_batch_stride, k_row_stride, k_head_stride, v_batch_stride, v_row_stride,
+        v_head_stride, num_splits);
+}
+
+template <typename Tdata>
+INFINIOP_METAX_KERNEL flashAttentionDecodeHd256SplitKvCombine(
+    Tdata *out,
+    const float *partial_acc,
+    const float *partial_m,
+    const float *partial_l,
+    int num_splits,
+    ptrdiff_t o_stride) {
+    op::paged_attention::cuda::flashAttentionDecodeSplitKvCombineWarpKernel<Tdata, 256>(
+        out, partial_acc, partial_m, partial_l, num_splits, o_stride);
+}
+
+template <typename Tindex>
+infiniStatus_t launch_decode_hd256_impl(
+    void *workspace,
+    size_t workspace_size,
+    void *out,
+    const void *q,
+    const void *k_cache,
+    const void *v_cache,
+    infiniDtype_t dtype,
+    const Tindex *block_tables,
+    const Tindex *cache_lens,
+    const float *alibi_slopes,
+    size_t num_heads,
+    size_t num_seqs,
+    size_t num_kv_heads,
+    float scale,
+    size_t max_num_blocks_per_seq,
+    size_t page_block_size,
+    ptrdiff_t q_stride,
+    ptrdiff_t k_batch_stride,
+    ptrdiff_t k_row_stride,
+    ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride,
+    ptrdiff_t v_row_stride,
+    ptrdiff_t v_head_stride,
+    ptrdiff_t o_stride,
+    hcStream_t stream) {
+    (void)workspace;
+    (void)workspace_size;
+
+    const dim3 grid(static_cast<uint64_t>(num_heads), static_cast<uint64_t>(num_seqs), 1);
+    const dim3 block(32);
+
+    constexpr int kMaxSplits = 8;
+    bool use_split = true;
+    if (const char *env = std::getenv("INFINIOP_FLASH_DECODE_SPLITKV")) {
+        use_split = !(std::strcmp(env, "0") == 0 || std::strcmp(env, "false") == 0);
+    }
+    int num_splits = 4;
+    if (const char *env = std::getenv("INFINIOP_FLASH_NUM_SPLITS")) {
+        const int v = std::atoi(env);
+        if (v > 0) {
+            num_splits = v;
+        }
+    }
+    if (num_splits < 1) {
+        num_splits = 1;
+    }
+    if (num_splits > kMaxSplits) {
+        num_splits = kMaxSplits;
+    }
+    use_split = use_split && num_splits > 1;
+
+    if (use_split) {
+        const size_t n = num_seqs * num_heads;
+        const size_t acc_elems = static_cast<size_t>(num_splits) * n * 256;
+        const size_t m_elems = static_cast<size_t>(num_splits) * n;
+        const size_t l_elems = static_cast<size_t>(num_splits) * n;
+        const size_t needed_bytes = (acc_elems + m_elems + l_elems) * sizeof(float);
+        if (workspace == nullptr || workspace_size < needed_bytes) {
+            return INFINI_STATUS_INSUFFICIENT_WORKSPACE;
+        }
+        float *ws = static_cast<float *>(workspace);
+        float *partial_acc = ws;
+        float *partial_m = partial_acc + acc_elems;
+        float *partial_l = partial_m + m_elems;
+        const dim3 grid_split(static_cast<uint64_t>(num_heads), static_cast<uint64_t>(num_seqs), static_cast<uint64_t>(num_splits));
+
+        if (dtype == INFINI_DTYPE_F16) {
+            flashAttentionDecodeHd256SplitKv<Tindex, half><<<grid_split, block, 0, stream>>>(
+                partial_acc, partial_m, partial_l,
+                static_cast<const half *>(q),
+                static_cast<const half *>(k_cache),
+                static_cast<const half *>(v_cache),
+                block_tables, cache_lens, alibi_slopes,
+                num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+                q_stride, k_batch_stride, k_row_stride, k_head_stride,
+                v_batch_stride, v_row_stride, v_head_stride, num_splits);
+            flashAttentionDecodeHd256SplitKvCombine<half><<<grid, block, 0, stream>>>(
+                static_cast<half *>(out), partial_acc, partial_m, partial_l, num_splits, o_stride);
+            return INFINI_STATUS_SUCCESS;
+        }
+        if (dtype == INFINI_DTYPE_BF16) {
+            flashAttentionDecodeHd256SplitKv<Tindex, __nv_bfloat16><<<grid_split, block, 0, stream>>>(
+                partial_acc, partial_m, partial_l,
+                static_cast<const __nv_bfloat16 *>(q),
+                static_cast<const __nv_bfloat16 *>(k_cache),
+                static_cast<const __nv_bfloat16 *>(v_cache),
+                block_tables, cache_lens, alibi_slopes,
+                num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+                q_stride, k_batch_stride, k_row_stride, k_head_stride,
+                v_batch_stride, v_row_stride, v_head_stride, num_splits);
+            flashAttentionDecodeHd256SplitKvCombine<__nv_bfloat16><<<grid, block, 0, stream>>>(
+                static_cast<__nv_bfloat16 *>(out), partial_acc, partial_m, partial_l, num_splits, o_stride);
+            return INFINI_STATUS_SUCCESS;
+        }
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+
+    if (dtype == INFINI_DTYPE_F16) {
+        flashAttentionDecodeHd256Warp<Tindex, half><<<grid, block, 0, stream>>>(
+            static_cast<half *>(out),
+            static_cast<const half *>(q),
+            static_cast<const half *>(k_cache),
+            static_cast<const half *>(v_cache),
+            block_tables, cache_lens, alibi_slopes,
+            num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+            q_stride, k_batch_stride, k_row_stride, k_head_stride,
+            v_batch_stride, v_row_stride, v_head_stride, o_stride);
+        return INFINI_STATUS_SUCCESS;
+    }
+    if (dtype == INFINI_DTYPE_BF16) {
+        flashAttentionDecodeHd256Warp<Tindex, __nv_bfloat16><<<grid, block, 0, stream>>>(
+            static_cast<__nv_bfloat16 *>(out),
+            static_cast<const __nv_bfloat16 *>(q),
+            static_cast<const __nv_bfloat16 *>(k_cache),
+            static_cast<const __nv_bfloat16 *>(v_cache),
+            block_tables, cache_lens, alibi_slopes,
+            num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+            q_stride, k_batch_stride, k_row_stride, k_head_stride,
+            v_batch_stride, v_row_stride, v_head_stride, o_stride);
+        return INFINI_STATUS_SUCCESS;
+    }
+    return INFINI_STATUS_BAD_TENSOR_DTYPE;
+}
+
+infiniStatus_t launch_decode_hd256_i64(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int64_t *block_tables, const int64_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    hcStream_t stream) {
+    return launch_decode_hd256_impl<int64_t>(
+        workspace, workspace_size, out, q, k_cache, v_cache, dtype, block_tables, cache_lens, alibi_slopes,
+        num_heads, num_seqs, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+        q_stride, k_batch_stride, k_row_stride, k_head_stride,
+        v_batch_stride, v_row_stride, v_head_stride, o_stride, stream);
+}
+
+infiniStatus_t launch_decode_hd256_i32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int32_t *block_tables, const int32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    hcStream_t stream) {
+    return launch_decode_hd256_impl<int32_t>(
+        workspace, workspace_size, out, q, k_cache, v_cache, dtype, block_tables, cache_lens, alibi_slopes,
+        num_heads, num_seqs, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+        q_stride, k_batch_stride, k_row_stride, k_head_stride,
+        v_batch_stride, v_row_stride, v_head_stride, o_stride, stream);
+}
+
+infiniStatus_t launch_decode_hd256_u32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const uint32_t *block_tables, const uint32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    hcStream_t stream) {
+    return launch_decode_hd256_impl<uint32_t>(
+        workspace, workspace_size, out, q, k_cache, v_cache, dtype, block_tables, cache_lens, alibi_slopes,
+        num_heads, num_seqs, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+        q_stride, k_batch_stride, k_row_stride, k_head_stride,
+        v_batch_stride, v_row_stride, v_head_stride, o_stride, stream);
+}
+
+} // namespace op::paged_attention::metax

--- a/src/infiniop/ops/paged_attention/metax/paged_attention_metax.maca
+++ b/src/infiniop/ops/paged_attention/metax/paged_attention_metax.maca
@@ -93,6 +93,32 @@ infiniStatus_t launch_decode_hd192_u32(
     ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
     ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
     hcStream_t stream);
+infiniStatus_t launch_decode_hd256_i64(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int64_t *block_tables, const int64_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    hcStream_t stream);
+
+infiniStatus_t launch_decode_hd256_i32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int32_t *block_tables, const int32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    hcStream_t stream);
+
+infiniStatus_t launch_decode_hd256_u32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const uint32_t *block_tables, const uint32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    hcStream_t stream);
 
 infiniStatus_t launch_decode_hd576_i64(
     void *workspace, size_t workspace_size,
@@ -196,7 +222,7 @@ infiniStatus_t Descriptor::calculate(
         need_workspace = (std::strcmp(env, "auto") == 0) || (std::strcmp(env, "1") == 0) || (std::strcmp(env, "true") == 0);
     } else {
         // Keep hd64 behavior unchanged, but for hd128 we default to split-kv decode, which needs workspace.
-        need_workspace = (_info.head_size == 128 || _info.head_size == 192 || _info.head_size == 576);
+        need_workspace = (_info.head_size == 128 || _info.head_size == 192 || _info.head_size == 256 || _info.head_size == 576);
     }
     if (need_workspace && workspace_size < _workspace_size) {
         return INFINI_STATUS_INSUFFICIENT_WORKSPACE;
@@ -243,6 +269,16 @@ infiniStatus_t Descriptor::calculate(
                 _info.o_stride, stream);
         case 192:
             return launch_decode_hd192_i64(
+                workspace, workspace_size,
+                out, q, k_cache, v_cache, _info.dtype,
+                block_table_i64, cache_lens_i64, alibi_ptr,
+                _info.num_heads, _info.num_seqs, _info.num_kv_heads, _info.scale,
+                _info.max_num_blocks_per_seq, _info.page_block_size,
+                _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
+                _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
+                _info.o_stride, stream);
+        case 256:
+            return launch_decode_hd256_i64(
                 workspace, workspace_size,
                 out, q, k_cache, v_cache, _info.dtype,
                 block_table_i64, cache_lens_i64, alibi_ptr,
@@ -311,6 +347,16 @@ infiniStatus_t Descriptor::calculate(
                 _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
                 _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
                 _info.o_stride, stream);
+        case 256:
+            return launch_decode_hd256_i32(
+                workspace, workspace_size,
+                out, q, k_cache, v_cache, _info.dtype,
+                block_table_i32, cache_lens_i32, alibi_ptr,
+                _info.num_heads, _info.num_seqs, _info.num_kv_heads, _info.scale,
+                _info.max_num_blocks_per_seq, _info.page_block_size,
+                _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
+                _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
+                _info.o_stride, stream);
         case 576:
             return launch_decode_hd576_i32(
                 workspace, workspace_size,
@@ -363,6 +409,16 @@ infiniStatus_t Descriptor::calculate(
                 _info.o_stride, stream);
         case 192:
             return launch_decode_hd192_u32(
+                workspace, workspace_size,
+                out, q, k_cache, v_cache, _info.dtype,
+                block_table_u32, cache_lens_u32, alibi_ptr,
+                _info.num_heads, _info.num_seqs, _info.num_kv_heads, _info.scale,
+                _info.max_num_blocks_per_seq, _info.page_block_size,
+                _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
+                _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
+                _info.o_stride, stream);
+        case 256:
+            return launch_decode_hd256_u32(
                 workspace, workspace_size,
                 out, q, k_cache, v_cache, _info.dtype,
                 block_table_u32, cache_lens_u32, alibi_ptr,

--- a/src/infiniop/ops/paged_attention/moore/paged_attention_hd256.mu
+++ b/src/infiniop/ops/paged_attention/moore/paged_attention_hd256.mu
@@ -1,0 +1,255 @@
+#include <musa_runtime.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+#include "../../../devices/moore/moore_common.h"
+#include "../../../devices/moore/moore_kernel_common.h"
+#include "../cuda/kernel_v2.cuh"
+
+namespace op::paged_attention::moore {
+
+template <typename Tindex, typename Tdata>
+INFINIOP_MOORE_KERNEL flashAttentionDecodeHd256Warp(
+    Tdata *out,
+    const Tdata *q,
+    const Tdata *k_cache,
+    const Tdata *v_cache,
+    const Tindex *block_tables,
+    const Tindex *cache_lens,
+    const float *alibi_slopes,
+    size_t num_kv_heads,
+    float scale,
+    size_t max_num_blocks_per_seq,
+    size_t page_block_size,
+    ptrdiff_t q_stride,
+    ptrdiff_t k_batch_stride,
+    ptrdiff_t k_row_stride,
+    ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride,
+    ptrdiff_t v_row_stride,
+    ptrdiff_t v_head_stride,
+    ptrdiff_t o_stride) {
+    op::paged_attention::cuda::flashAttentionDecodeWarpKernel<Tindex, Tdata, 256>(
+        out, q, k_cache, v_cache, block_tables, cache_lens, alibi_slopes,
+        num_kv_heads, scale, max_num_blocks_per_seq, page_block_size, q_stride,
+        k_batch_stride, k_row_stride, k_head_stride, v_batch_stride, v_row_stride,
+        v_head_stride, o_stride);
+}
+
+template <typename Tindex, typename Tdata>
+INFINIOP_MOORE_KERNEL flashAttentionDecodeHd256SplitKv(
+    float *partial_acc,
+    float *partial_m,
+    float *partial_l,
+    const Tdata *q,
+    const Tdata *k_cache,
+    const Tdata *v_cache,
+    const Tindex *block_tables,
+    const Tindex *cache_lens,
+    const float *alibi_slopes,
+    size_t num_kv_heads,
+    float scale,
+    size_t max_num_blocks_per_seq,
+    size_t page_block_size,
+    ptrdiff_t q_stride,
+    ptrdiff_t k_batch_stride,
+    ptrdiff_t k_row_stride,
+    ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride,
+    ptrdiff_t v_row_stride,
+    ptrdiff_t v_head_stride,
+    int num_splits) {
+    op::paged_attention::cuda::flashAttentionDecodeSplitKvWarpKernel<Tindex, Tdata, 256>(
+        partial_acc, partial_m, partial_l,
+        q, k_cache, v_cache, block_tables, cache_lens, alibi_slopes,
+        num_kv_heads, scale, max_num_blocks_per_seq, page_block_size, q_stride,
+        k_batch_stride, k_row_stride, k_head_stride, v_batch_stride, v_row_stride,
+        v_head_stride, num_splits);
+}
+
+template <typename Tdata>
+INFINIOP_MOORE_KERNEL flashAttentionDecodeHd256SplitKvCombine(
+    Tdata *out,
+    const float *partial_acc,
+    const float *partial_m,
+    const float *partial_l,
+    int num_splits,
+    ptrdiff_t o_stride) {
+    op::paged_attention::cuda::flashAttentionDecodeSplitKvCombineWarpKernel<Tdata, 256>(
+        out, partial_acc, partial_m, partial_l, num_splits, o_stride);
+}
+
+template <typename Tindex>
+infiniStatus_t launch_decode_hd256_impl(
+    void *workspace,
+    size_t workspace_size,
+    void *out,
+    const void *q,
+    const void *k_cache,
+    const void *v_cache,
+    infiniDtype_t dtype,
+    const Tindex *block_tables,
+    const Tindex *cache_lens,
+    const float *alibi_slopes,
+    size_t num_heads,
+    size_t num_seqs,
+    size_t num_kv_heads,
+    float scale,
+    size_t max_num_blocks_per_seq,
+    size_t page_block_size,
+    ptrdiff_t q_stride,
+    ptrdiff_t k_batch_stride,
+    ptrdiff_t k_row_stride,
+    ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride,
+    ptrdiff_t v_row_stride,
+    ptrdiff_t v_head_stride,
+    ptrdiff_t o_stride,
+    musaStream_t stream) {
+    (void)workspace;
+    (void)workspace_size;
+
+    const dim3 grid(static_cast<uint64_t>(num_heads), static_cast<uint64_t>(num_seqs), 1);
+    const dim3 block(32);
+
+    constexpr int kMaxSplits = 8;
+    bool use_split = true;
+    if (const char *env = std::getenv("INFINIOP_FLASH_DECODE_SPLITKV")) {
+        use_split = !(std::strcmp(env, "0") == 0 || std::strcmp(env, "false") == 0);
+    }
+    int num_splits = 4;
+    if (const char *env = std::getenv("INFINIOP_FLASH_NUM_SPLITS")) {
+        const int v = std::atoi(env);
+        if (v > 0) {
+            num_splits = v;
+        }
+    }
+    if (num_splits < 1) {
+        num_splits = 1;
+    }
+    if (num_splits > kMaxSplits) {
+        num_splits = kMaxSplits;
+    }
+    use_split = use_split && num_splits > 1;
+
+    if (use_split) {
+        const size_t n = num_seqs * num_heads;
+        const size_t acc_elems = static_cast<size_t>(num_splits) * n * 256;
+        const size_t m_elems = static_cast<size_t>(num_splits) * n;
+        const size_t l_elems = static_cast<size_t>(num_splits) * n;
+        const size_t needed_bytes = (acc_elems + m_elems + l_elems) * sizeof(float);
+        if (workspace == nullptr || workspace_size < needed_bytes) {
+            return INFINI_STATUS_INSUFFICIENT_WORKSPACE;
+        }
+        float *ws = static_cast<float *>(workspace);
+        float *partial_acc = ws;
+        float *partial_m = partial_acc + acc_elems;
+        float *partial_l = partial_m + m_elems;
+        const dim3 grid_split(static_cast<uint64_t>(num_heads), static_cast<uint64_t>(num_seqs), static_cast<uint64_t>(num_splits));
+
+        if (dtype == INFINI_DTYPE_F16) {
+            flashAttentionDecodeHd256SplitKv<Tindex, half><<<grid_split, block, 0, stream>>>(
+                partial_acc, partial_m, partial_l,
+                static_cast<const half *>(q),
+                static_cast<const half *>(k_cache),
+                static_cast<const half *>(v_cache),
+                block_tables, cache_lens, alibi_slopes,
+                num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+                q_stride, k_batch_stride, k_row_stride, k_head_stride,
+                v_batch_stride, v_row_stride, v_head_stride, num_splits);
+            flashAttentionDecodeHd256SplitKvCombine<half><<<grid, block, 0, stream>>>(
+                static_cast<half *>(out), partial_acc, partial_m, partial_l, num_splits, o_stride);
+            return INFINI_STATUS_SUCCESS;
+        }
+        if (dtype == INFINI_DTYPE_BF16) {
+            flashAttentionDecodeHd256SplitKv<Tindex, __nv_bfloat16><<<grid_split, block, 0, stream>>>(
+                partial_acc, partial_m, partial_l,
+                static_cast<const __nv_bfloat16 *>(q),
+                static_cast<const __nv_bfloat16 *>(k_cache),
+                static_cast<const __nv_bfloat16 *>(v_cache),
+                block_tables, cache_lens, alibi_slopes,
+                num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+                q_stride, k_batch_stride, k_row_stride, k_head_stride,
+                v_batch_stride, v_row_stride, v_head_stride, num_splits);
+            flashAttentionDecodeHd256SplitKvCombine<__nv_bfloat16><<<grid, block, 0, stream>>>(
+                static_cast<__nv_bfloat16 *>(out), partial_acc, partial_m, partial_l, num_splits, o_stride);
+            return INFINI_STATUS_SUCCESS;
+        }
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+
+    if (dtype == INFINI_DTYPE_F16) {
+        flashAttentionDecodeHd256Warp<Tindex, half><<<grid, block, 0, stream>>>(
+            static_cast<half *>(out),
+            static_cast<const half *>(q),
+            static_cast<const half *>(k_cache),
+            static_cast<const half *>(v_cache),
+            block_tables, cache_lens, alibi_slopes,
+            num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+            q_stride, k_batch_stride, k_row_stride, k_head_stride,
+            v_batch_stride, v_row_stride, v_head_stride, o_stride);
+        return INFINI_STATUS_SUCCESS;
+    }
+    if (dtype == INFINI_DTYPE_BF16) {
+        flashAttentionDecodeHd256Warp<Tindex, __nv_bfloat16><<<grid, block, 0, stream>>>(
+            static_cast<__nv_bfloat16 *>(out),
+            static_cast<const __nv_bfloat16 *>(q),
+            static_cast<const __nv_bfloat16 *>(k_cache),
+            static_cast<const __nv_bfloat16 *>(v_cache),
+            block_tables, cache_lens, alibi_slopes,
+            num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+            q_stride, k_batch_stride, k_row_stride, k_head_stride,
+            v_batch_stride, v_row_stride, v_head_stride, o_stride);
+        return INFINI_STATUS_SUCCESS;
+    }
+    return INFINI_STATUS_BAD_TENSOR_DTYPE;
+}
+
+infiniStatus_t launch_decode_hd256_i64(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int64_t *block_tables, const int64_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    musaStream_t stream) {
+    return launch_decode_hd256_impl<int64_t>(
+        workspace, workspace_size, out, q, k_cache, v_cache, dtype, block_tables, cache_lens, alibi_slopes,
+        num_heads, num_seqs, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+        q_stride, k_batch_stride, k_row_stride, k_head_stride,
+        v_batch_stride, v_row_stride, v_head_stride, o_stride, stream);
+}
+
+infiniStatus_t launch_decode_hd256_i32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int32_t *block_tables, const int32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    musaStream_t stream) {
+    return launch_decode_hd256_impl<int32_t>(
+        workspace, workspace_size, out, q, k_cache, v_cache, dtype, block_tables, cache_lens, alibi_slopes,
+        num_heads, num_seqs, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+        q_stride, k_batch_stride, k_row_stride, k_head_stride,
+        v_batch_stride, v_row_stride, v_head_stride, o_stride, stream);
+}
+
+infiniStatus_t launch_decode_hd256_u32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const uint32_t *block_tables, const uint32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    musaStream_t stream) {
+    return launch_decode_hd256_impl<uint32_t>(
+        workspace, workspace_size, out, q, k_cache, v_cache, dtype, block_tables, cache_lens, alibi_slopes,
+        num_heads, num_seqs, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+        q_stride, k_batch_stride, k_row_stride, k_head_stride,
+        v_batch_stride, v_row_stride, v_head_stride, o_stride, stream);
+}
+
+} // namespace op::paged_attention::moore

--- a/src/infiniop/ops/paged_attention/moore/paged_attention_moore.mu
+++ b/src/infiniop/ops/paged_attention/moore/paged_attention_moore.mu
@@ -89,6 +89,32 @@ infiniStatus_t launch_decode_hd192_u32(
     ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
     ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
     musaStream_t stream);
+infiniStatus_t launch_decode_hd256_i64(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int64_t *block_tables, const int64_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    musaStream_t stream);
+
+infiniStatus_t launch_decode_hd256_i32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int32_t *block_tables, const int32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    musaStream_t stream);
+
+infiniStatus_t launch_decode_hd256_u32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const uint32_t *block_tables, const uint32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    musaStream_t stream);
 
 infiniStatus_t launch_decode_hd576_i64(
     void *workspace, size_t workspace_size,
@@ -192,7 +218,7 @@ infiniStatus_t Descriptor::calculate(
         need_workspace = (std::strcmp(env, "auto") == 0) || (std::strcmp(env, "1") == 0) || (std::strcmp(env, "true") == 0);
     } else {
         // Keep hd64 behavior unchanged, but for hd128 we default to split-kv decode, which needs workspace.
-        need_workspace = (_info.head_size == 128 || _info.head_size == 192 || _info.head_size == 576);
+        need_workspace = (_info.head_size == 128 || _info.head_size == 192 || _info.head_size == 256 || _info.head_size == 576);
     }
     if (need_workspace && workspace_size < _workspace_size) {
         return INFINI_STATUS_INSUFFICIENT_WORKSPACE;
@@ -239,6 +265,16 @@ infiniStatus_t Descriptor::calculate(
                 _info.o_stride, stream);
         case 192:
             return launch_decode_hd192_i64(
+                workspace, workspace_size,
+                out, q, k_cache, v_cache, _info.dtype,
+                block_table_i64, cache_lens_i64, alibi_ptr,
+                _info.num_heads, _info.num_seqs, _info.num_kv_heads, _info.scale,
+                _info.max_num_blocks_per_seq, _info.page_block_size,
+                _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
+                _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
+                _info.o_stride, stream);
+        case 256:
+            return launch_decode_hd256_i64(
                 workspace, workspace_size,
                 out, q, k_cache, v_cache, _info.dtype,
                 block_table_i64, cache_lens_i64, alibi_ptr,
@@ -307,6 +343,16 @@ infiniStatus_t Descriptor::calculate(
                 _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
                 _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
                 _info.o_stride, stream);
+        case 256:
+            return launch_decode_hd256_i32(
+                workspace, workspace_size,
+                out, q, k_cache, v_cache, _info.dtype,
+                block_table_i32, cache_lens_i32, alibi_ptr,
+                _info.num_heads, _info.num_seqs, _info.num_kv_heads, _info.scale,
+                _info.max_num_blocks_per_seq, _info.page_block_size,
+                _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
+                _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
+                _info.o_stride, stream);
         case 576:
             return launch_decode_hd576_i32(
                 workspace, workspace_size,
@@ -359,6 +405,16 @@ infiniStatus_t Descriptor::calculate(
                 _info.o_stride, stream);
         case 192:
             return launch_decode_hd192_u32(
+                workspace, workspace_size,
+                out, q, k_cache, v_cache, _info.dtype,
+                block_table_u32, cache_lens_u32, alibi_ptr,
+                _info.num_heads, _info.num_seqs, _info.num_kv_heads, _info.scale,
+                _info.max_num_blocks_per_seq, _info.page_block_size,
+                _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
+                _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
+                _info.o_stride, stream);
+        case 256:
+            return launch_decode_hd256_u32(
                 workspace, workspace_size,
                 out, q, k_cache, v_cache, _info.dtype,
                 block_table_u32, cache_lens_u32, alibi_ptr,

--- a/src/infiniop/ops/paged_attention/nvidia/paged_attention_hd256.cu
+++ b/src/infiniop/ops/paged_attention/nvidia/paged_attention_hd256.cu
@@ -1,0 +1,257 @@
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+#include "../../../devices/nvidia/nvidia_common.cuh"
+#include "../../../devices/nvidia/nvidia_kernel_common.cuh"
+#include "../cuda/kernel_v2.cuh"
+
+namespace op::paged_attention::nvidia {
+
+template <typename Tindex, typename Tdata>
+INFINIOP_CUDA_KERNEL flashAttentionDecodeHd256Warp(
+    Tdata *out,
+    const Tdata *q,
+    const Tdata *k_cache,
+    const Tdata *v_cache,
+    const Tindex *block_tables,
+    const Tindex *cache_lens,
+    const float *alibi_slopes,
+    size_t num_kv_heads,
+    float scale,
+    size_t max_num_blocks_per_seq,
+    size_t page_block_size,
+    ptrdiff_t q_stride,
+    ptrdiff_t k_batch_stride,
+    ptrdiff_t k_row_stride,
+    ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride,
+    ptrdiff_t v_row_stride,
+    ptrdiff_t v_head_stride,
+    ptrdiff_t o_stride) {
+    op::paged_attention::cuda::flashAttentionDecodeWarpKernel<Tindex, Tdata, 256>(
+        out, q, k_cache, v_cache, block_tables, cache_lens, alibi_slopes,
+        num_kv_heads, scale, max_num_blocks_per_seq, page_block_size, q_stride,
+        k_batch_stride, k_row_stride, k_head_stride, v_batch_stride, v_row_stride,
+        v_head_stride, o_stride);
+}
+
+template <typename Tindex, typename Tdata>
+INFINIOP_CUDA_KERNEL flashAttentionDecodeHd256SplitKv(
+    float *partial_acc,
+    float *partial_m,
+    float *partial_l,
+    const Tdata *q,
+    const Tdata *k_cache,
+    const Tdata *v_cache,
+    const Tindex *block_tables,
+    const Tindex *cache_lens,
+    const float *alibi_slopes,
+    size_t num_kv_heads,
+    float scale,
+    size_t max_num_blocks_per_seq,
+    size_t page_block_size,
+    ptrdiff_t q_stride,
+    ptrdiff_t k_batch_stride,
+    ptrdiff_t k_row_stride,
+    ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride,
+    ptrdiff_t v_row_stride,
+    ptrdiff_t v_head_stride,
+    int num_splits) {
+    op::paged_attention::cuda::flashAttentionDecodeSplitKvWarpKernel<Tindex, Tdata, 256>(
+        partial_acc, partial_m, partial_l,
+        q, k_cache, v_cache, block_tables, cache_lens, alibi_slopes,
+        num_kv_heads, scale, max_num_blocks_per_seq, page_block_size, q_stride,
+        k_batch_stride, k_row_stride, k_head_stride, v_batch_stride, v_row_stride,
+        v_head_stride, num_splits);
+}
+
+template <typename Tdata>
+INFINIOP_CUDA_KERNEL flashAttentionDecodeHd256SplitKvCombine(
+    Tdata *out,
+    const float *partial_acc,
+    const float *partial_m,
+    const float *partial_l,
+    int num_splits,
+    ptrdiff_t o_stride) {
+    op::paged_attention::cuda::flashAttentionDecodeSplitKvCombineWarpKernel<Tdata, 256>(
+        out, partial_acc, partial_m, partial_l, num_splits, o_stride);
+}
+
+template <typename Tindex>
+infiniStatus_t launch_decode_hd256_impl(
+    void *workspace,
+    size_t workspace_size,
+    void *out,
+    const void *q,
+    const void *k_cache,
+    const void *v_cache,
+    infiniDtype_t dtype,
+    const Tindex *block_tables,
+    const Tindex *cache_lens,
+    const float *alibi_slopes,
+    size_t num_heads,
+    size_t num_seqs,
+    size_t num_kv_heads,
+    float scale,
+    size_t max_num_blocks_per_seq,
+    size_t page_block_size,
+    ptrdiff_t q_stride,
+    ptrdiff_t k_batch_stride,
+    ptrdiff_t k_row_stride,
+    ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride,
+    ptrdiff_t v_row_stride,
+    ptrdiff_t v_head_stride,
+    ptrdiff_t o_stride,
+    cudaStream_t stream) {
+    (void)workspace;
+    (void)workspace_size;
+
+    const dim3 grid(static_cast<uint64_t>(num_heads), static_cast<uint64_t>(num_seqs), 1);
+    const dim3 block(32);
+
+    constexpr int kMaxSplits = 8;
+    bool use_split = true;
+    if (const char *env = std::getenv("INFINIOP_FLASH_DECODE_SPLITKV")) {
+        use_split = !(std::strcmp(env, "0") == 0 || std::strcmp(env, "false") == 0);
+    }
+    int num_splits = 4;
+    if (const char *env = std::getenv("INFINIOP_FLASH_NUM_SPLITS")) {
+        const int v = std::atoi(env);
+        if (v > 0) {
+            num_splits = v;
+        }
+    }
+    if (num_splits < 1) {
+        num_splits = 1;
+    }
+    if (num_splits > kMaxSplits) {
+        num_splits = kMaxSplits;
+    }
+    use_split = use_split && num_splits > 1;
+
+    if (use_split) {
+        const size_t n = num_seqs * num_heads;
+        const size_t acc_elems = static_cast<size_t>(num_splits) * n * 256;
+        const size_t m_elems = static_cast<size_t>(num_splits) * n;
+        const size_t l_elems = static_cast<size_t>(num_splits) * n;
+        const size_t needed_bytes = (acc_elems + m_elems + l_elems) * sizeof(float);
+        if (workspace == nullptr || workspace_size < needed_bytes) {
+            return INFINI_STATUS_INSUFFICIENT_WORKSPACE;
+        }
+        float *ws = static_cast<float *>(workspace);
+        float *partial_acc = ws;
+        float *partial_m = partial_acc + acc_elems;
+        float *partial_l = partial_m + m_elems;
+        const dim3 grid_split(static_cast<uint64_t>(num_heads), static_cast<uint64_t>(num_seqs), static_cast<uint64_t>(num_splits));
+
+        if (dtype == INFINI_DTYPE_F16) {
+            flashAttentionDecodeHd256SplitKv<Tindex, half><<<grid_split, block, 0, stream>>>(
+                partial_acc, partial_m, partial_l,
+                static_cast<const half *>(q),
+                static_cast<const half *>(k_cache),
+                static_cast<const half *>(v_cache),
+                block_tables, cache_lens, alibi_slopes,
+                num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+                q_stride, k_batch_stride, k_row_stride, k_head_stride,
+                v_batch_stride, v_row_stride, v_head_stride, num_splits);
+            flashAttentionDecodeHd256SplitKvCombine<half><<<grid, block, 0, stream>>>(
+                static_cast<half *>(out), partial_acc, partial_m, partial_l, num_splits, o_stride);
+            return INFINI_STATUS_SUCCESS;
+        }
+        if (dtype == INFINI_DTYPE_BF16) {
+            flashAttentionDecodeHd256SplitKv<Tindex, __nv_bfloat16><<<grid_split, block, 0, stream>>>(
+                partial_acc, partial_m, partial_l,
+                static_cast<const __nv_bfloat16 *>(q),
+                static_cast<const __nv_bfloat16 *>(k_cache),
+                static_cast<const __nv_bfloat16 *>(v_cache),
+                block_tables, cache_lens, alibi_slopes,
+                num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+                q_stride, k_batch_stride, k_row_stride, k_head_stride,
+                v_batch_stride, v_row_stride, v_head_stride, num_splits);
+            flashAttentionDecodeHd256SplitKvCombine<__nv_bfloat16><<<grid, block, 0, stream>>>(
+                static_cast<__nv_bfloat16 *>(out), partial_acc, partial_m, partial_l, num_splits, o_stride);
+            return INFINI_STATUS_SUCCESS;
+        }
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+
+    if (dtype == INFINI_DTYPE_F16) {
+        flashAttentionDecodeHd256Warp<Tindex, half><<<grid, block, 0, stream>>>(
+            static_cast<half *>(out),
+            static_cast<const half *>(q),
+            static_cast<const half *>(k_cache),
+            static_cast<const half *>(v_cache),
+            block_tables, cache_lens, alibi_slopes,
+            num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+            q_stride, k_batch_stride, k_row_stride, k_head_stride,
+            v_batch_stride, v_row_stride, v_head_stride, o_stride);
+        return INFINI_STATUS_SUCCESS;
+    }
+    if (dtype == INFINI_DTYPE_BF16) {
+        flashAttentionDecodeHd256Warp<Tindex, __nv_bfloat16><<<grid, block, 0, stream>>>(
+            static_cast<__nv_bfloat16 *>(out),
+            static_cast<const __nv_bfloat16 *>(q),
+            static_cast<const __nv_bfloat16 *>(k_cache),
+            static_cast<const __nv_bfloat16 *>(v_cache),
+            block_tables, cache_lens, alibi_slopes,
+            num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+            q_stride, k_batch_stride, k_row_stride, k_head_stride,
+            v_batch_stride, v_row_stride, v_head_stride, o_stride);
+        return INFINI_STATUS_SUCCESS;
+    }
+    return INFINI_STATUS_BAD_TENSOR_DTYPE;
+}
+
+infiniStatus_t launch_decode_hd256_i64(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int64_t *block_tables, const int64_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    cudaStream_t stream) {
+    return launch_decode_hd256_impl<int64_t>(
+        workspace, workspace_size, out, q, k_cache, v_cache, dtype, block_tables, cache_lens, alibi_slopes,
+        num_heads, num_seqs, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+        q_stride, k_batch_stride, k_row_stride, k_head_stride,
+        v_batch_stride, v_row_stride, v_head_stride, o_stride, stream);
+}
+
+infiniStatus_t launch_decode_hd256_i32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int32_t *block_tables, const int32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    cudaStream_t stream) {
+    return launch_decode_hd256_impl<int32_t>(
+        workspace, workspace_size, out, q, k_cache, v_cache, dtype, block_tables, cache_lens, alibi_slopes,
+        num_heads, num_seqs, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+        q_stride, k_batch_stride, k_row_stride, k_head_stride,
+        v_batch_stride, v_row_stride, v_head_stride, o_stride, stream);
+}
+
+infiniStatus_t launch_decode_hd256_u32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const uint32_t *block_tables, const uint32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    cudaStream_t stream) {
+    return launch_decode_hd256_impl<uint32_t>(
+        workspace, workspace_size, out, q, k_cache, v_cache, dtype, block_tables, cache_lens, alibi_slopes,
+        num_heads, num_seqs, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+        q_stride, k_batch_stride, k_row_stride, k_head_stride,
+        v_batch_stride, v_row_stride, v_head_stride, o_stride, stream);
+}
+
+} // namespace op::paged_attention::nvidia

--- a/src/infiniop/ops/paged_attention/nvidia/paged_attention_nvidia.cu
+++ b/src/infiniop/ops/paged_attention/nvidia/paged_attention_nvidia.cu
@@ -90,6 +90,33 @@ infiniStatus_t launch_decode_hd192_u32(
     ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
     cudaStream_t stream);
 
+infiniStatus_t launch_decode_hd256_i64(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int64_t *block_tables, const int64_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    cudaStream_t stream);
+
+infiniStatus_t launch_decode_hd256_i32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const int32_t *block_tables, const int32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    cudaStream_t stream);
+
+infiniStatus_t launch_decode_hd256_u32(
+    void *workspace, size_t workspace_size,
+    void *out, const void *q, const void *k_cache, const void *v_cache,
+    infiniDtype_t dtype, const uint32_t *block_tables, const uint32_t *cache_lens, const float *alibi_slopes,
+    size_t num_heads, size_t num_seqs, size_t num_kv_heads, float scale, size_t max_num_blocks_per_seq, size_t page_block_size,
+    ptrdiff_t q_stride, ptrdiff_t k_batch_stride, ptrdiff_t k_row_stride, ptrdiff_t k_head_stride,
+    ptrdiff_t v_batch_stride, ptrdiff_t v_row_stride, ptrdiff_t v_head_stride, ptrdiff_t o_stride,
+    cudaStream_t stream);
+
 infiniStatus_t launch_decode_hd576_i64(
     void *workspace, size_t workspace_size,
     void *out, const void *q, const void *k_cache, const void *v_cache,
@@ -192,7 +219,7 @@ infiniStatus_t Descriptor::calculate(
         need_workspace = (std::strcmp(env, "auto") == 0) || (std::strcmp(env, "1") == 0) || (std::strcmp(env, "true") == 0);
     } else {
         // Keep hd64 behavior unchanged, but for hd128 we default to split-kv decode, which needs workspace.
-        need_workspace = (_info.head_size == 128 || _info.head_size == 192 || _info.head_size == 576);
+        need_workspace = (_info.head_size == 128 || _info.head_size == 192 || _info.head_size == 256 || _info.head_size == 576);
     }
     if (need_workspace && workspace_size < _workspace_size) {
         return INFINI_STATUS_INSUFFICIENT_WORKSPACE;
@@ -239,6 +266,16 @@ infiniStatus_t Descriptor::calculate(
                 _info.o_stride, stream);
         case 192:
             return launch_decode_hd192_i64(
+                workspace, workspace_size,
+                out, q, k_cache, v_cache, _info.dtype,
+                block_table_i64, cache_lens_i64, alibi_ptr,
+                _info.num_heads, _info.num_seqs, _info.num_kv_heads, _info.scale,
+                _info.max_num_blocks_per_seq, _info.page_block_size,
+                _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
+                _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
+                _info.o_stride, stream);
+        case 256:
+            return launch_decode_hd256_i64(
                 workspace, workspace_size,
                 out, q, k_cache, v_cache, _info.dtype,
                 block_table_i64, cache_lens_i64, alibi_ptr,
@@ -307,6 +344,16 @@ infiniStatus_t Descriptor::calculate(
                 _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
                 _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
                 _info.o_stride, stream);
+        case 256:
+            return launch_decode_hd256_i32(
+                workspace, workspace_size,
+                out, q, k_cache, v_cache, _info.dtype,
+                block_table_i32, cache_lens_i32, alibi_ptr,
+                _info.num_heads, _info.num_seqs, _info.num_kv_heads, _info.scale,
+                _info.max_num_blocks_per_seq, _info.page_block_size,
+                _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
+                _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
+                _info.o_stride, stream);
         case 576:
             return launch_decode_hd576_i32(
                 workspace, workspace_size,
@@ -359,6 +406,16 @@ infiniStatus_t Descriptor::calculate(
                 _info.o_stride, stream);
         case 192:
             return launch_decode_hd192_u32(
+                workspace, workspace_size,
+                out, q, k_cache, v_cache, _info.dtype,
+                block_table_u32, cache_lens_u32, alibi_ptr,
+                _info.num_heads, _info.num_seqs, _info.num_kv_heads, _info.scale,
+                _info.max_num_blocks_per_seq, _info.page_block_size,
+                _info.q_stride, _info.k_batch_stride, _info.k_row_stride, _info.k_head_stride,
+                _info.v_batch_stride, _info.v_row_stride, _info.v_head_stride,
+                _info.o_stride, stream);
+        case 256:
+            return launch_decode_hd256_u32(
                 workspace, workspace_size,
                 out, q, k_cache, v_cache, _info.dtype,
                 block_table_u32, cache_lens_u32, alibi_ptr,

--- a/src/infiniop/ops/paged_attention_prefill/info.h
+++ b/src/infiniop/ops/paged_attention_prefill/info.h
@@ -116,7 +116,7 @@ public:
         const size_t page_block_size = k_shape[2];
         const size_t num_kv_heads = k_shape[1];
 
-        if (head_size != 64 && head_size != 128 && head_size != 192 && head_size != 576) {
+        if (head_size != 64 && head_size != 128 && head_size != 192 && head_size != 256 && head_size != 576) {
             return INFINI_STATUS_BAD_TENSOR_SHAPE;
         }
         if (num_heads % num_kv_heads != 0) {

--- a/src/infiniop/ops/paged_attention_prefill/metax/paged_attention_prefill_metax.maca
+++ b/src/infiniop/ops/paged_attention_prefill/metax/paged_attention_prefill_metax.maca
@@ -28,6 +28,9 @@ inline const char *default_prefill_kernel(const PagedAttentionPrefillInfo &info)
     if (info.head_size == 576) {
         return "ref";
     }
+    if (info.head_size == 256) {
+        return "ref";
+    }
     if (info.head_size == 192) {
         return "warp";
     }
@@ -787,6 +790,18 @@ infiniStatus_t launch_prefill_ref(
 
     if (head_size == 192) {
         op::paged_attention_prefill::cuda::PagedAttentionPrefillReferenceKernel<Tindex, Tdata, Tcompute, 192>
+            <<<grid, block, 0, stream>>>(
+                out, q, k_cache, v_cache, block_tables, total_kv_lens, cu_seqlens_q, alibi_slopes,
+                num_heads, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+                block_table_batch_stride, q_stride, q_head_stride,
+                k_batch_stride, k_row_stride, k_head_stride,
+                v_batch_stride, v_row_stride, v_head_stride,
+                o_stride, o_head_stride, num_seqs);
+        return INFINI_STATUS_SUCCESS;
+    }
+
+    if (head_size == 256) {
+        op::paged_attention_prefill::cuda::PagedAttentionPrefillReferenceKernel<Tindex, Tdata, Tcompute, 256>
             <<<grid, block, 0, stream>>>(
                 out, q, k_cache, v_cache, block_tables, total_kv_lens, cu_seqlens_q, alibi_slopes,
                 num_heads, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,

--- a/src/infiniop/ops/paged_attention_prefill/nvidia/paged_attention_prefill_nvidia.cu
+++ b/src/infiniop/ops/paged_attention_prefill/nvidia/paged_attention_prefill_nvidia.cu
@@ -26,6 +26,9 @@ inline const char *default_prefill_kernel(const PagedAttentionPrefillInfo &info)
     if (info.head_size == 576) {
         return "ref";
     }
+    if (info.head_size == 256) {
+        return "ref";
+    }
     // Iluvatar/Hygon: use warp for the non-MLA shapes where it is the stable path.
 #if defined(ENABLE_ILUVATAR_API) || defined(ENABLE_HYGON_API)
     (void)info;
@@ -907,6 +910,18 @@ infiniStatus_t launch_prefill_ref(
 
     if (head_size == 192) {
         op::paged_attention_prefill::cuda::PagedAttentionPrefillReferenceKernel<Tindex, Tdata, Tcompute, 192>
+            <<<grid, block, 0, stream>>>(
+                out, q, k_cache, v_cache, block_tables, total_kv_lens, cu_seqlens_q, alibi_slopes,
+                num_heads, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,
+                block_table_batch_stride, q_stride, q_head_stride,
+                k_batch_stride, k_row_stride, k_head_stride,
+                v_batch_stride, v_row_stride, v_head_stride,
+                o_stride, o_head_stride, num_seqs);
+        return INFINI_STATUS_SUCCESS;
+    }
+
+    if (head_size == 256) {
+        op::paged_attention_prefill::cuda::PagedAttentionPrefillReferenceKernel<Tindex, Tdata, Tcompute, 256>
             <<<grid, block, 0, stream>>>(
                 out, q, k_cache, v_cache, block_tables, total_kv_lens, cu_seqlens_q, alibi_slopes,
                 num_heads, num_kv_heads, scale, max_num_blocks_per_seq, page_block_size,

--- a/test/infinicore/framework/tensor.py
+++ b/test/infinicore/framework/tensor.py
@@ -84,7 +84,7 @@ class TensorInitializer:
                 raise ValueError(
                     f"Shape mismatch: expected {shape}, got {tensor.shape}"
                 )
-            return tensor.to(torch_dtype).to(torch_device_str)
+            return tensor.to(torch_dtype).to(torch_device_str).contiguous()
         elif mode == TensorInitializer.BINARY:
             tensor = kwargs.get("set_tensor")
             if tensor is None:

--- a/test/infinicore/ops/paged_attention.py
+++ b/test/infinicore/ops/paged_attention.py
@@ -27,6 +27,10 @@ _TEST_CASES_DATA = [
     (3, 8, 8, 128, 16, 1024, False),
     (3, 8, 8, 64, 16, 1024, False),
     (8, 64, 8, 128, 16, 2048, False),
+    # Qwen3.6/Qwen3.5 full attention local TP shapes: head_dim=value_dim=256, GQA ratio=6.
+    (1, 24, 4, 256, 16, 32, False),
+    (1, 12, 2, 256, 16, 32, False),
+    (1, 6, 1, 256, 16, 32, False),
     # New DeepSeek MLA wrapper case: verifies decode output uses the
     # value head size when q/k head size is 576 and value size is 512.
     (1, 16, 1, 576, 16, 32, False, 512),

--- a/test/infinicore/ops/paged_attention_prefill.py
+++ b/test/infinicore/ops/paged_attention_prefill.py
@@ -22,6 +22,10 @@ _TEST_CASES_DATA = [
     (2, 8, 8, 128, 16, 32, 2),
     (4, 16, 16, 128, 8, 64, 3),
     (8, 64, 64, 128, 8, 16, 5),
+    # Qwen3.6/Qwen3.5 full attention local TP shapes: head_dim=value_dim=256, GQA ratio=6.
+    (1, 24, 4, 256, 8, 8, 1),
+    (1, 12, 2, 256, 8, 8, 1),
+    (1, 6, 1, 256, 8, 8, 1),
     # New DeepSeek MLA wrapper case: verifies prefill supports q/k head
     # size 576 with value head size 512.
     (1, 16, 1, 576, 8, 8, 1, 512),
@@ -209,6 +213,11 @@ def ref_paged_attention_multi_turn(
 
         K = torch.stack(keys, dim=0)
         V = torch.stack(values, dim=0)
+        num_query_heads, num_kv_heads = cur_q.shape[1], K.shape[1]
+        num_queries_per_kv = num_query_heads // num_kv_heads
+        if num_queries_per_kv > 1:
+            K = torch.repeat_interleave(K, num_queries_per_kv, dim=1)
+            V = torch.repeat_interleave(V, num_queries_per_kv, dim=1)
 
         scores = torch.einsum("qhd,khd->hqk", cur_q.float(), K.float()) * scale
         mask = torch.full((q_len, total_len), float("-inf"), device=query.device)


### PR DESCRIPTION
metax-hpcc:
<img width="2592" height="494" alt="image" src="https://github.com/user-attachments/assets/bca9e4cd-77aa-4136-a9df-bcb34dc639f3" />
<img width="2558" height="500" alt="image" src="https://github.com/user-attachments/assets/9a76a3da-225c-40f1-9514-137fd14e0832" />

metax-maca
<img width="2552" height="484" alt="image" src="https://github.com/user-attachments/assets/0b7562cd-c582-407d-a846-f6109e35af4a" />
<img width="2564" height="494" alt="image" src="https://github.com/user-attachments/assets/d6e8ef7d-da02-45bc-8e79-a44b70f73f20" />

moore
<img width="2574" height="540" alt="image" src="https://github.com/user-attachments/assets/73633ec3-3bac-4229-bbd8-39b84f7732e5" />
<img width="2580" height="484" alt="image" src="https://github.com/user-attachments/assets/75082194-31b3-40f8-a889-b6db3f1f3fd3" />

nv
<img width="2562" height="522" alt="image" src="https://github.com/user-attachments/assets/bfe3faa8-05ff-4a31-8a70-2fc74e708203" />
<img width="2574" height="488" alt="image" src="https://github.com/user-attachments/assets/c19df882-c14d-4088-9c92-0ad7ca86d30a" />


