### PR TITLE
feat: mrope, sigmoid, gelu on Metax/Moore

### DIFF
--- a/src/infiniop/ops/gelu/moore/gelu_moore.h
+++ b/src/infiniop/ops/gelu/moore/gelu_moore.h
@@ -1,0 +1,8 @@
+#ifndef __GELU_MOORE_API_H__
+#define __GELU_MOORE_API_H__
+
+#include "../../../elementwise/moore/elementwise_moore_api.h"
+
+ELEMENTWISE_DESCRIPTOR(gelu, moore)
+
+#endif // __GELU_MOORE_API_H__

--- a/src/infiniop/ops/gelu/moore/gelu_moore.mu
+++ b/src/infiniop/ops/gelu/moore/gelu_moore.mu
@@ -1,0 +1,76 @@
+#include "../../../elementwise/moore/elementwise_moore.h"
+#include "gelu_moore.h"
+
+#include <cmath>
+#include <type_traits>
+
+namespace op::gelu::moore {
+
+struct GeluOp {
+    static constexpr size_t num_inputs = 1;
+
+    template <typename T>
+    __device__ __forceinline__ T operator()(const T &x) const {
+        if constexpr (std::is_same_v<T, half>) {
+            float xf = __half2float(x);
+            float result = 0.5f * xf * (1.0f + erff(xf * 0.7071067811865476f));
+            return __float2half(result);
+        } else if constexpr (std::is_same_v<T, cuda_bfloat16>) {
+            float xf = __bfloat162float(x);
+            float result = 0.5f * xf * (1.0f + erff(xf * 0.7071067811865476f));
+            return __float2bfloat16_rn(result);
+        } else if constexpr (std::is_same_v<T, float>) {
+            return 0.5f * x * (1.0f + erff(x * 0.7071067811865476f));
+        } else {
+            double xd = static_cast<double>(x);
+            return static_cast<T>(0.5 * xd * (1.0 + erf(xd * 0.7071067811865476)));
+        }
+    }
+};
+
+Descriptor::~Descriptor() = default;
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle_,
+    Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t out_desc,
+    std::vector<infiniopTensorDescriptor_t> input_desc_vec) {
+
+    auto handle = reinterpret_cast<device::moore::Handle *>(handle_);
+    auto dtype = out_desc->dtype();
+    const auto &input_desc = input_desc_vec.at(0);
+
+    CHECK_DTYPE(dtype, INFINI_DTYPE_BF16, INFINI_DTYPE_F16, INFINI_DTYPE_F32, INFINI_DTYPE_F64);
+    CHECK_SAME_SHAPE(out_desc->shape(), input_desc->shape());
+
+    CREATE_ELEMENTWISE_MOORE_DESCRIPTOR(handle, dtype, out_desc, input_desc_vec)
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(
+    void *workspace,
+    size_t workspace_size,
+    void *output,
+    std::vector<const void *> inputs,
+    void *stream) const {
+
+    if (workspace_size < _workspace_size) {
+        return INFINI_STATUS_INSUFFICIENT_WORKSPACE;
+    }
+
+    switch (_dtype) {
+    case INFINI_DTYPE_BF16:
+        return _device_info->calculate<256, GeluOp, cuda_bfloat16>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_F16:
+        return _device_info->calculate<256, GeluOp, half>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_F32:
+        return _device_info->calculate<256, GeluOp, float>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_F64:
+        return _device_info->calculate<256, GeluOp, double>(_info, workspace, output, inputs, stream);
+    default:
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+}
+
+} // namespace op::gelu::moore

--- a/src/infiniop/ops/gelu/operator.cc
+++ b/src/infiniop/ops/gelu/operator.cc
@@ -11,6 +11,9 @@
 #ifdef ENABLE_METAX_API
 #include "metax/gelu_metax.h"
 #endif
+#ifdef ENABLE_MOORE_API
+#include "moore/gelu_moore.h"
+#endif
 #ifdef ENABLE_KUNLUN_API
 #include "kunlun/gelu_kunlun.h"
 #endif
@@ -51,6 +54,9 @@ __INFINI_C infiniStatus_t infiniopCreateGeluDescriptor(
 #endif
 #ifdef ENABLE_METAX_API
         CREATE(INFINI_DEVICE_METAX, metax);
+#endif
+#ifdef ENABLE_MOORE_API
+        CREATE(INFINI_DEVICE_MOORE, moore);
 #endif
 #ifdef ENABLE_KUNLUN_API
         CREATE(INFINI_DEVICE_KUNLUN, kunlun);
@@ -94,6 +100,9 @@ __INFINI_C infiniStatus_t infiniopGetGeluWorkspaceSize(infiniopGeluDescriptor_t 
 #endif
 #ifdef ENABLE_METAX_API
         GET(INFINI_DEVICE_METAX, metax);
+#endif
+#ifdef ENABLE_MOORE_API
+        GET(INFINI_DEVICE_MOORE, moore);
 #endif
 #ifdef ENABLE_KUNLUN_API
         GET(INFINI_DEVICE_KUNLUN, kunlun);
@@ -146,6 +155,9 @@ __INFINI_C infiniStatus_t infiniopGelu(
 #ifdef ENABLE_METAX_API
         CALCULATE(INFINI_DEVICE_METAX, metax);
 #endif
+#ifdef ENABLE_MOORE_API
+        CALCULATE(INFINI_DEVICE_MOORE, moore);
+#endif
 #ifdef ENABLE_KUNLUN_API
         CALCULATE(INFINI_DEVICE_KUNLUN, kunlun);
 #endif
@@ -190,6 +202,9 @@ infiniopDestroyGeluDescriptor(infiniopGeluDescriptor_t desc) {
 #endif
 #ifdef ENABLE_METAX_API
         DELETE(INFINI_DEVICE_METAX, metax);
+#endif
+#ifdef ENABLE_MOORE_API
+        DELETE(INFINI_DEVICE_MOORE, moore);
 #endif
 #ifdef ENABLE_KUNLUN_API
         DELETE(INFINI_DEVICE_KUNLUN, kunlun);

--- a/src/infiniop/ops/mrope/metax/mrope_metax.h
+++ b/src/infiniop/ops/mrope/metax/mrope_metax.h
@@ -1,0 +1,8 @@
+#ifndef __MROPE_METAX_H__
+#define __MROPE_METAX_H__
+
+#include "../mrope.h"
+
+DESCRIPTOR(metax)
+
+#endif // __MROPE_METAX_H__

--- a/src/infiniop/ops/mrope/metax/mrope_metax.maca
+++ b/src/infiniop/ops/mrope/metax/mrope_metax.maca
@@ -1,0 +1,191 @@
+#include "../../../devices/metax/metax_common.h"
+#include "mrope_metax.h"
+
+#include "../../../devices/metax/metax_kernel_common.h"
+
+#include <algorithm>
+
+#include "../cuda/kernel.cuh"
+
+namespace {
+
+template <typename Tdata, typename Tpos>
+INFINIOP_METAX_KERNEL mropeKernel(
+    Tdata *q_out,
+    Tdata *k_out,
+    const Tdata *q,
+    const Tdata *k,
+    const Tdata *cos,
+    const Tdata *sin,
+    const Tpos *positions,
+    size_t num_q_heads,
+    size_t num_kv_heads,
+    size_t head_size,
+    size_t rotary_dim,
+    size_t half_rotary_dim,
+    ptrdiff_t q_out_stride_token,
+    ptrdiff_t q_out_stride_head,
+    ptrdiff_t k_out_stride_token,
+    ptrdiff_t k_out_stride_head,
+    ptrdiff_t q_stride_token,
+    ptrdiff_t q_stride_head,
+    ptrdiff_t k_stride_token,
+    ptrdiff_t k_stride_head,
+    ptrdiff_t cos_stride_position,
+    ptrdiff_t sin_stride_position,
+    ptrdiff_t positions_stride_axis,
+    ptrdiff_t positions_stride_token,
+    size_t max_position_embeddings,
+    size_t section_t,
+    size_t section_h,
+    size_t section_w,
+    bool positions_has_axes,
+    bool interleaved) {
+    op::mrope::cuda::mropeBlock<Tdata, float, Tpos>(
+        q_out, k_out, q, k, cos, sin, positions, num_q_heads, num_kv_heads, head_size, rotary_dim, half_rotary_dim,
+        q_out_stride_token, q_out_stride_head, k_out_stride_token, k_out_stride_head,
+        q_stride_token, q_stride_head, k_stride_token, k_stride_head,
+        cos_stride_position, sin_stride_position,
+        positions_stride_axis, positions_stride_token, max_position_embeddings,
+        section_t, section_h, section_w, positions_has_axes, interleaved);
+}
+
+template <typename Tdata, typename Tpos>
+infiniStatus_t launchMRoPE(
+    const MRoPEInfo &info,
+    int block_size,
+    Tdata *q_out,
+    Tdata *k_out,
+    const Tdata *q,
+    const Tdata *k,
+    const Tdata *cos,
+    const Tdata *sin,
+    const Tpos *positions,
+    hcStream_t stream) {
+    dim3 grid_dim(uint32_t(info.num_tokens), uint32_t(std::max(info.num_q_heads, info.num_kv_heads)));
+    int nthreads = std::max(int(info.half_rotary_dim), std::min(block_size, 256));
+    mropeKernel<Tdata, Tpos><<<grid_dim, nthreads, 0, stream>>>(
+        q_out, k_out, q, k, cos, sin, positions,
+        info.num_q_heads, info.num_kv_heads, info.head_size, info.rotary_dim, info.half_rotary_dim,
+        info.q_out_stride_token, info.q_out_stride_head, info.k_out_stride_token, info.k_out_stride_head,
+        info.q_stride_token, info.q_stride_head, info.k_stride_token, info.k_stride_head,
+        info.cos_stride_position, info.sin_stride_position,
+        info.positions_stride_axis, info.positions_stride_token, info.max_position_embeddings,
+        info.section_t, info.section_h, info.section_w, info.positions_has_axes, info.interleaved);
+    CHECK_METAX(hcGetLastError());
+    return INFINI_STATUS_SUCCESS;
+}
+
+} // namespace
+
+namespace op::mrope::metax {
+
+struct Descriptor::Opaque {
+    std::shared_ptr<device::metax::Handle::Internal> internal;
+};
+
+Descriptor::~Descriptor() {
+    delete _opaque;
+}
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle_,
+    Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t q_out_desc,
+    infiniopTensorDescriptor_t k_out_desc,
+    infiniopTensorDescriptor_t q_desc,
+    infiniopTensorDescriptor_t k_desc,
+    infiniopTensorDescriptor_t cos_desc,
+    infiniopTensorDescriptor_t sin_desc,
+    infiniopTensorDescriptor_t positions_desc,
+    int head_size,
+    int rotary_dim,
+    int section_t,
+    int section_h,
+    int section_w,
+    bool interleaved) {
+    auto handle = reinterpret_cast<device::metax::Handle *>(handle_);
+    auto info = MRoPEInfo::create(q_out_desc, k_out_desc, q_desc, k_desc, cos_desc, sin_desc, positions_desc,
+                                  head_size, rotary_dim, section_t, section_h, section_w, interleaved);
+    CHECK_RESULT(info);
+    *desc_ptr = new Descriptor(
+        info.take(),
+        0,
+        new Opaque{handle->internal()},
+        handle->device,
+        handle->device_id);
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(
+    void *workspace,
+    size_t workspace_size,
+    void *q_out,
+    void *k_out,
+    const void *q,
+    const void *k,
+    const void *cos,
+    const void *sin,
+    const void *positions,
+    void *stream) const {
+    (void)workspace;
+    (void)workspace_size;
+    switch (_info.data_type) {
+    case INFINI_DTYPE_F16:
+        if (_info.position_type == INFINI_DTYPE_I32) {
+            return launchMRoPE<half, int32_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                              static_cast<half *>(q_out), static_cast<half *>(k_out),
+                                              static_cast<const half *>(q), static_cast<const half *>(k),
+                                              static_cast<const half *>(cos), static_cast<const half *>(sin),
+                                              static_cast<const int32_t *>(positions), static_cast<hcStream_t>(stream));
+        }
+        return launchMRoPE<half, int64_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                          static_cast<half *>(q_out), static_cast<half *>(k_out),
+                                          static_cast<const half *>(q), static_cast<const half *>(k),
+                                          static_cast<const half *>(cos), static_cast<const half *>(sin),
+                                          static_cast<const int64_t *>(positions), static_cast<hcStream_t>(stream));
+    case INFINI_DTYPE_BF16:
+        if (_info.position_type == INFINI_DTYPE_I32) {
+            return launchMRoPE<cuda_bfloat16, int32_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                                       static_cast<cuda_bfloat16 *>(q_out), static_cast<cuda_bfloat16 *>(k_out),
+                                                       static_cast<const cuda_bfloat16 *>(q), static_cast<const cuda_bfloat16 *>(k),
+                                                       static_cast<const cuda_bfloat16 *>(cos), static_cast<const cuda_bfloat16 *>(sin),
+                                                       static_cast<const int32_t *>(positions), static_cast<hcStream_t>(stream));
+        }
+        return launchMRoPE<cuda_bfloat16, int64_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                                   static_cast<cuda_bfloat16 *>(q_out), static_cast<cuda_bfloat16 *>(k_out),
+                                                   static_cast<const cuda_bfloat16 *>(q), static_cast<const cuda_bfloat16 *>(k),
+                                                   static_cast<const cuda_bfloat16 *>(cos), static_cast<const cuda_bfloat16 *>(sin),
+                                                   static_cast<const int64_t *>(positions), static_cast<hcStream_t>(stream));
+    case INFINI_DTYPE_F32:
+        if (_info.position_type == INFINI_DTYPE_I32) {
+            return launchMRoPE<float, int32_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                               static_cast<float *>(q_out), static_cast<float *>(k_out),
+                                               static_cast<const float *>(q), static_cast<const float *>(k),
+                                               static_cast<const float *>(cos), static_cast<const float *>(sin),
+                                               static_cast<const int32_t *>(positions), static_cast<hcStream_t>(stream));
+        }
+        return launchMRoPE<float, int64_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                           static_cast<float *>(q_out), static_cast<float *>(k_out),
+                                           static_cast<const float *>(q), static_cast<const float *>(k),
+                                           static_cast<const float *>(cos), static_cast<const float *>(sin),
+                                           static_cast<const int64_t *>(positions), static_cast<hcStream_t>(stream));
+    case INFINI_DTYPE_F64:
+        if (_info.position_type == INFINI_DTYPE_I32) {
+            return launchMRoPE<double, int32_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                                static_cast<double *>(q_out), static_cast<double *>(k_out),
+                                                static_cast<const double *>(q), static_cast<const double *>(k),
+                                                static_cast<const double *>(cos), static_cast<const double *>(sin),
+                                                static_cast<const int32_t *>(positions), static_cast<hcStream_t>(stream));
+        }
+        return launchMRoPE<double, int64_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                            static_cast<double *>(q_out), static_cast<double *>(k_out),
+                                            static_cast<const double *>(q), static_cast<const double *>(k),
+                                            static_cast<const double *>(cos), static_cast<const double *>(sin),
+                                            static_cast<const int64_t *>(positions), static_cast<hcStream_t>(stream));
+    default:
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+}
+
+} // namespace op::mrope::metax

--- a/src/infiniop/ops/mrope/moore/mrope_moore.h
+++ b/src/infiniop/ops/mrope/moore/mrope_moore.h
@@ -1,0 +1,8 @@
+#ifndef __MROPE_MOORE_H__
+#define __MROPE_MOORE_H__
+
+#include "../mrope.h"
+
+DESCRIPTOR(moore)
+
+#endif // __MROPE_MOORE_H__

--- a/src/infiniop/ops/mrope/moore/mrope_moore.mu
+++ b/src/infiniop/ops/mrope/moore/mrope_moore.mu
@@ -1,0 +1,191 @@
+#include "../../../devices/moore/moore_common.h"
+#include "mrope_moore.h"
+
+#include "../../../devices/moore/moore_kernel_common.h"
+
+#include <algorithm>
+
+#include "../cuda/kernel.cuh"
+
+namespace {
+
+template <typename Tdata, typename Tpos>
+INFINIOP_MOORE_KERNEL mropeKernel(
+    Tdata *q_out,
+    Tdata *k_out,
+    const Tdata *q,
+    const Tdata *k,
+    const Tdata *cos,
+    const Tdata *sin,
+    const Tpos *positions,
+    size_t num_q_heads,
+    size_t num_kv_heads,
+    size_t head_size,
+    size_t rotary_dim,
+    size_t half_rotary_dim,
+    ptrdiff_t q_out_stride_token,
+    ptrdiff_t q_out_stride_head,
+    ptrdiff_t k_out_stride_token,
+    ptrdiff_t k_out_stride_head,
+    ptrdiff_t q_stride_token,
+    ptrdiff_t q_stride_head,
+    ptrdiff_t k_stride_token,
+    ptrdiff_t k_stride_head,
+    ptrdiff_t cos_stride_position,
+    ptrdiff_t sin_stride_position,
+    ptrdiff_t positions_stride_axis,
+    ptrdiff_t positions_stride_token,
+    size_t max_position_embeddings,
+    size_t section_t,
+    size_t section_h,
+    size_t section_w,
+    bool positions_has_axes,
+    bool interleaved) {
+    op::mrope::cuda::mropeBlock<Tdata, float, Tpos>(
+        q_out, k_out, q, k, cos, sin, positions, num_q_heads, num_kv_heads, head_size, rotary_dim, half_rotary_dim,
+        q_out_stride_token, q_out_stride_head, k_out_stride_token, k_out_stride_head,
+        q_stride_token, q_stride_head, k_stride_token, k_stride_head,
+        cos_stride_position, sin_stride_position,
+        positions_stride_axis, positions_stride_token, max_position_embeddings,
+        section_t, section_h, section_w, positions_has_axes, interleaved);
+}
+
+template <typename Tdata, typename Tpos>
+infiniStatus_t launchMRoPE(
+    const MRoPEInfo &info,
+    int block_size,
+    Tdata *q_out,
+    Tdata *k_out,
+    const Tdata *q,
+    const Tdata *k,
+    const Tdata *cos,
+    const Tdata *sin,
+    const Tpos *positions,
+    musaStream_t stream) {
+    dim3 grid_dim(uint32_t(info.num_tokens), uint32_t(std::max(info.num_q_heads, info.num_kv_heads)));
+    int nthreads = std::max(int(info.half_rotary_dim), std::min(block_size, 256));
+    mropeKernel<Tdata, Tpos><<<grid_dim, nthreads, 0, stream>>>(
+        q_out, k_out, q, k, cos, sin, positions,
+        info.num_q_heads, info.num_kv_heads, info.head_size, info.rotary_dim, info.half_rotary_dim,
+        info.q_out_stride_token, info.q_out_stride_head, info.k_out_stride_token, info.k_out_stride_head,
+        info.q_stride_token, info.q_stride_head, info.k_stride_token, info.k_stride_head,
+        info.cos_stride_position, info.sin_stride_position,
+        info.positions_stride_axis, info.positions_stride_token, info.max_position_embeddings,
+        info.section_t, info.section_h, info.section_w, info.positions_has_axes, info.interleaved);
+    CHECK_MOORE(musaGetLastError());
+    return INFINI_STATUS_SUCCESS;
+}
+
+} // namespace
+
+namespace op::mrope::moore {
+
+struct Descriptor::Opaque {
+    std::shared_ptr<device::moore::Handle::Internal> internal;
+};
+
+Descriptor::~Descriptor() {
+    delete _opaque;
+}
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle_,
+    Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t q_out_desc,
+    infiniopTensorDescriptor_t k_out_desc,
+    infiniopTensorDescriptor_t q_desc,
+    infiniopTensorDescriptor_t k_desc,
+    infiniopTensorDescriptor_t cos_desc,
+    infiniopTensorDescriptor_t sin_desc,
+    infiniopTensorDescriptor_t positions_desc,
+    int head_size,
+    int rotary_dim,
+    int section_t,
+    int section_h,
+    int section_w,
+    bool interleaved) {
+    auto handle = reinterpret_cast<device::moore::Handle *>(handle_);
+    auto info = MRoPEInfo::create(q_out_desc, k_out_desc, q_desc, k_desc, cos_desc, sin_desc, positions_desc,
+                                  head_size, rotary_dim, section_t, section_h, section_w, interleaved);
+    CHECK_RESULT(info);
+    *desc_ptr = new Descriptor(
+        info.take(),
+        0,
+        new Opaque{handle->internal()},
+        handle->device,
+        handle->device_id);
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(
+    void *workspace,
+    size_t workspace_size,
+    void *q_out,
+    void *k_out,
+    const void *q,
+    const void *k,
+    const void *cos,
+    const void *sin,
+    const void *positions,
+    void *stream) const {
+    (void)workspace;
+    (void)workspace_size;
+    switch (_info.data_type) {
+    case INFINI_DTYPE_F16:
+        if (_info.position_type == INFINI_DTYPE_I32) {
+            return launchMRoPE<half, int32_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                              static_cast<half *>(q_out), static_cast<half *>(k_out),
+                                              static_cast<const half *>(q), static_cast<const half *>(k),
+                                              static_cast<const half *>(cos), static_cast<const half *>(sin),
+                                              static_cast<const int32_t *>(positions), static_cast<musaStream_t>(stream));
+        }
+        return launchMRoPE<half, int64_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                          static_cast<half *>(q_out), static_cast<half *>(k_out),
+                                          static_cast<const half *>(q), static_cast<const half *>(k),
+                                          static_cast<const half *>(cos), static_cast<const half *>(sin),
+                                          static_cast<const int64_t *>(positions), static_cast<musaStream_t>(stream));
+    case INFINI_DTYPE_BF16:
+        if (_info.position_type == INFINI_DTYPE_I32) {
+            return launchMRoPE<cuda_bfloat16, int32_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                                       static_cast<cuda_bfloat16 *>(q_out), static_cast<cuda_bfloat16 *>(k_out),
+                                                       static_cast<const cuda_bfloat16 *>(q), static_cast<const cuda_bfloat16 *>(k),
+                                                       static_cast<const cuda_bfloat16 *>(cos), static_cast<const cuda_bfloat16 *>(sin),
+                                                       static_cast<const int32_t *>(positions), static_cast<musaStream_t>(stream));
+        }
+        return launchMRoPE<cuda_bfloat16, int64_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                                   static_cast<cuda_bfloat16 *>(q_out), static_cast<cuda_bfloat16 *>(k_out),
+                                                   static_cast<const cuda_bfloat16 *>(q), static_cast<const cuda_bfloat16 *>(k),
+                                                   static_cast<const cuda_bfloat16 *>(cos), static_cast<const cuda_bfloat16 *>(sin),
+                                                   static_cast<const int64_t *>(positions), static_cast<musaStream_t>(stream));
+    case INFINI_DTYPE_F32:
+        if (_info.position_type == INFINI_DTYPE_I32) {
+            return launchMRoPE<float, int32_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                               static_cast<float *>(q_out), static_cast<float *>(k_out),
+                                               static_cast<const float *>(q), static_cast<const float *>(k),
+                                               static_cast<const float *>(cos), static_cast<const float *>(sin),
+                                               static_cast<const int32_t *>(positions), static_cast<musaStream_t>(stream));
+        }
+        return launchMRoPE<float, int64_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                           static_cast<float *>(q_out), static_cast<float *>(k_out),
+                                           static_cast<const float *>(q), static_cast<const float *>(k),
+                                           static_cast<const float *>(cos), static_cast<const float *>(sin),
+                                           static_cast<const int64_t *>(positions), static_cast<musaStream_t>(stream));
+    case INFINI_DTYPE_F64:
+        if (_info.position_type == INFINI_DTYPE_I32) {
+            return launchMRoPE<double, int32_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                                static_cast<double *>(q_out), static_cast<double *>(k_out),
+                                                static_cast<const double *>(q), static_cast<const double *>(k),
+                                                static_cast<const double *>(cos), static_cast<const double *>(sin),
+                                                static_cast<const int32_t *>(positions), static_cast<musaStream_t>(stream));
+        }
+        return launchMRoPE<double, int64_t>(_info, _opaque->internal->maxThreadsPerBlock(),
+                                            static_cast<double *>(q_out), static_cast<double *>(k_out),
+                                            static_cast<const double *>(q), static_cast<const double *>(k),
+                                            static_cast<const double *>(cos), static_cast<const double *>(sin),
+                                            static_cast<const int64_t *>(positions), static_cast<musaStream_t>(stream));
+    default:
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+}
+
+} // namespace op::mrope::moore

--- a/src/infiniop/ops/mrope/operator.cc
+++ b/src/infiniop/ops/mrope/operator.cc
@@ -5,6 +5,12 @@
 #if defined(ENABLE_NVIDIA_API) || defined(ENABLE_ILUVATAR_API) || defined(ENABLE_QY_API) || defined(ENABLE_HYGON_API) || defined(ENABLE_ALI_API)
 #include "nvidia/mrope_nvidia.cuh"
 #endif
+#ifdef ENABLE_METAX_API
+#include "metax/mrope_metax.h"
+#endif
+#ifdef ENABLE_MOORE_API
+#include "moore/mrope_moore.h"
+#endif
 
 __INFINI_C infiniStatus_t infiniopCreateMRoPEDescriptor(
     infiniopHandle_t handle,
@@ -47,6 +53,12 @@ __INFINI_C infiniStatus_t infiniopCreateMRoPEDescriptor(
 #ifdef ENABLE_HYGON_API
         CREATE(INFINI_DEVICE_HYGON, nvidia);
 #endif
+#ifdef ENABLE_METAX_API
+        CREATE(INFINI_DEVICE_METAX, metax);
+#endif
+#ifdef ENABLE_MOORE_API
+        CREATE(INFINI_DEVICE_MOORE, moore);
+#endif
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
     }
@@ -74,6 +86,12 @@ __INFINI_C infiniStatus_t infiniopGetMRoPEWorkspaceSize(infiniopMRoPEDescriptor_
 #endif
 #ifdef ENABLE_HYGON_API
         GET(INFINI_DEVICE_HYGON, nvidia);
+#endif
+#ifdef ENABLE_METAX_API
+        GET(INFINI_DEVICE_METAX, metax);
+#endif
+#ifdef ENABLE_MOORE_API
+        GET(INFINI_DEVICE_MOORE, moore);
 #endif
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
@@ -114,6 +132,12 @@ __INFINI_C infiniStatus_t infiniopMRoPE(
 #ifdef ENABLE_HYGON_API
         CALCULATE(INFINI_DEVICE_HYGON, nvidia);
 #endif
+#ifdef ENABLE_METAX_API
+        CALCULATE(INFINI_DEVICE_METAX, metax);
+#endif
+#ifdef ENABLE_MOORE_API
+        CALCULATE(INFINI_DEVICE_MOORE, moore);
+#endif
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
     }
@@ -141,6 +165,12 @@ __INFINI_C infiniStatus_t infiniopDestroyMRoPEDescriptor(infiniopMRoPEDescriptor
 #endif
 #ifdef ENABLE_HYGON_API
         DESTROY(INFINI_DEVICE_HYGON, nvidia);
+#endif
+#ifdef ENABLE_METAX_API
+        DESTROY(INFINI_DEVICE_METAX, metax);
+#endif
+#ifdef ENABLE_MOORE_API
+        DESTROY(INFINI_DEVICE_MOORE, moore);
 #endif
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;

--- a/src/infiniop/ops/sigmoid/metax/sigmoid_metax.h
+++ b/src/infiniop/ops/sigmoid/metax/sigmoid_metax.h
@@ -1,0 +1,8 @@
+#ifndef __SIGMOID_METAX_API_H__
+#define __SIGMOID_METAX_API_H__
+
+#include "../../../elementwise/metax/elementwise_metax_api.h"
+
+ELEMENTWISE_DESCRIPTOR(sigmoid, metax)
+
+#endif // __SIGMOID_METAX_API_H__

--- a/src/infiniop/ops/sigmoid/metax/sigmoid_metax.maca
+++ b/src/infiniop/ops/sigmoid/metax/sigmoid_metax.maca
@@ -1,0 +1,77 @@
+#include "sigmoid_metax.h"
+
+#include "../../../elementwise/metax/elementwise_metax.h"
+
+#include <cmath>
+#include <type_traits>
+
+namespace op::sigmoid::metax {
+
+struct SigmoidOp {
+    static constexpr size_t num_inputs = 1;
+
+    template <typename T>
+    __device__ __forceinline__ T operator()(const T &x) const {
+        if constexpr (std::is_same_v<T, half>) {
+            float xf = __half2float(x);
+            float result = xf >= 0.0f ? 1.0f / (1.0f + expf(-xf)) : expf(xf) / (1.0f + expf(xf));
+            return __float2half(result);
+        } else if constexpr (std::is_same_v<T, cuda_bfloat16>) {
+            float xf = __bfloat162float(x);
+            float result = xf >= 0.0f ? 1.0f / (1.0f + expf(-xf)) : expf(xf) / (1.0f + expf(xf));
+            return __float2bfloat16(result);
+        } else if constexpr (std::is_same_v<T, float>) {
+            return x >= 0.0f ? 1.0f / (1.0f + expf(-x)) : expf(x) / (1.0f + expf(x));
+        } else {
+            double xd = static_cast<double>(x);
+            return static_cast<T>(xd >= 0.0 ? 1.0 / (1.0 + exp(-xd)) : exp(xd) / (1.0 + exp(xd)));
+        }
+    }
+};
+
+Descriptor::~Descriptor() = default;
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle_,
+    Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t out_desc,
+    std::vector<infiniopTensorDescriptor_t> input_desc_vec) {
+
+    auto handle = reinterpret_cast<device::metax::Handle *>(handle_);
+    auto dtype = out_desc->dtype();
+    const auto &input_desc = input_desc_vec.at(0);
+
+    CHECK_DTYPE(dtype, INFINI_DTYPE_F16, INFINI_DTYPE_F32, INFINI_DTYPE_F64, INFINI_DTYPE_BF16);
+    CHECK_SAME_SHAPE(out_desc->shape(), input_desc->shape());
+
+    CREATE_ELEMENTWISE_METAX_DESCRIPTOR(handle, dtype, out_desc, input_desc_vec)
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(
+    void *workspace,
+    size_t workspace_size,
+    void *output,
+    std::vector<const void *> inputs,
+    void *stream) const {
+
+    if (workspace_size < _workspace_size) {
+        return INFINI_STATUS_INSUFFICIENT_WORKSPACE;
+    }
+
+    switch (_dtype) {
+    case INFINI_DTYPE_F16:
+        return _device_info->calculate<256, SigmoidOp, half>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_BF16:
+        return _device_info->calculate<256, SigmoidOp, cuda_bfloat16>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_F32:
+        return _device_info->calculate<256, SigmoidOp, float>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_F64:
+        return _device_info->calculate<256, SigmoidOp, double>(_info, workspace, output, inputs, stream);
+    default:
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+}
+
+} // namespace op::sigmoid::metax

--- a/src/infiniop/ops/sigmoid/moore/sigmoid_moore.h
+++ b/src/infiniop/ops/sigmoid/moore/sigmoid_moore.h
@@ -1,0 +1,8 @@
+#ifndef __SIGMOID_MOORE_API_H__
+#define __SIGMOID_MOORE_API_H__
+
+#include "../../../elementwise/moore/elementwise_moore_api.h"
+
+ELEMENTWISE_DESCRIPTOR(sigmoid, moore)
+
+#endif // __SIGMOID_MOORE_API_H__

--- a/src/infiniop/ops/sigmoid/moore/sigmoid_moore.mu
+++ b/src/infiniop/ops/sigmoid/moore/sigmoid_moore.mu
@@ -1,0 +1,76 @@
+#include "../../../elementwise/moore/elementwise_moore.h"
+#include "sigmoid_moore.h"
+
+#include <cmath>
+#include <type_traits>
+
+namespace op::sigmoid::moore {
+
+struct SigmoidOp {
+    static constexpr size_t num_inputs = 1;
+
+    template <typename T>
+    __device__ __forceinline__ T operator()(const T &x) const {
+        if constexpr (std::is_same_v<T, half>) {
+            float xf = __half2float(x);
+            float result = xf >= 0.0f ? 1.0f / (1.0f + expf(-xf)) : expf(xf) / (1.0f + expf(xf));
+            return __float2half(result);
+        } else if constexpr (std::is_same_v<T, cuda_bfloat16>) {
+            float xf = __bfloat162float(x);
+            float result = xf >= 0.0f ? 1.0f / (1.0f + expf(-xf)) : expf(xf) / (1.0f + expf(xf));
+            return __float2bfloat16_rn(result);
+        } else if constexpr (std::is_same_v<T, float>) {
+            return x >= 0.0f ? 1.0f / (1.0f + expf(-x)) : expf(x) / (1.0f + expf(x));
+        } else {
+            double xd = static_cast<double>(x);
+            return static_cast<T>(xd >= 0.0 ? 1.0 / (1.0 + exp(-xd)) : exp(xd) / (1.0 + exp(xd)));
+        }
+    }
+};
+
+Descriptor::~Descriptor() = default;
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle_,
+    Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t out_desc,
+    std::vector<infiniopTensorDescriptor_t> input_desc_vec) {
+
+    auto handle = reinterpret_cast<device::moore::Handle *>(handle_);
+    auto dtype = out_desc->dtype();
+    const auto &input_desc = input_desc_vec.at(0);
+
+    CHECK_DTYPE(dtype, INFINI_DTYPE_F16, INFINI_DTYPE_F32, INFINI_DTYPE_F64, INFINI_DTYPE_BF16);
+    CHECK_SAME_SHAPE(out_desc->shape(), input_desc->shape());
+
+    CREATE_ELEMENTWISE_MOORE_DESCRIPTOR(handle, dtype, out_desc, input_desc_vec)
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(
+    void *workspace,
+    size_t workspace_size,
+    void *output,
+    std::vector<const void *> inputs,
+    void *stream) const {
+
+    if (workspace_size < _workspace_size) {
+        return INFINI_STATUS_INSUFFICIENT_WORKSPACE;
+    }
+
+    switch (_dtype) {
+    case INFINI_DTYPE_F16:
+        return _device_info->calculate<256, SigmoidOp, half>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_BF16:
+        return _device_info->calculate<256, SigmoidOp, cuda_bfloat16>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_F32:
+        return _device_info->calculate<256, SigmoidOp, float>(_info, workspace, output, inputs, stream);
+    case INFINI_DTYPE_F64:
+        return _device_info->calculate<256, SigmoidOp, double>(_info, workspace, output, inputs, stream);
+    default:
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+}
+
+} // namespace op::sigmoid::moore

--- a/src/infiniop/ops/sigmoid/operator.cc
+++ b/src/infiniop/ops/sigmoid/operator.cc
@@ -8,6 +8,12 @@
 #if defined(ENABLE_NVIDIA_API) || defined(ENABLE_QY_API) || defined(ENABLE_ALI_API) || defined(ENABLE_ILUVATAR_API) || defined(ENABLE_HYGON_API)
 #include "nvidia/sigmoid_nvidia.cuh"
 #endif
+#ifdef ENABLE_METAX_API
+#include "metax/sigmoid_metax.h"
+#endif
+#ifdef ENABLE_MOORE_API
+#include "moore/sigmoid_moore.h"
+#endif
 
 __INFINI_C infiniStatus_t infiniopCreateSigmoidDescriptor(
     infiniopHandle_t handle,
@@ -43,6 +49,12 @@ __INFINI_C infiniStatus_t infiniopCreateSigmoidDescriptor(
 #ifdef ENABLE_HYGON_API
         CREATE(INFINI_DEVICE_HYGON, nvidia);
 #endif
+#ifdef ENABLE_METAX_API
+        CREATE(INFINI_DEVICE_METAX, metax);
+#endif
+#ifdef ENABLE_MOORE_API
+        CREATE(INFINI_DEVICE_MOORE, moore);
+#endif
 
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
@@ -76,6 +88,12 @@ __INFINI_C infiniStatus_t infiniopGetSigmoidWorkspaceSize(infiniopSigmoidDescrip
 #endif
 #ifdef ENABLE_HYGON_API
         GET(INFINI_DEVICE_HYGON, nvidia)
+#endif
+#ifdef ENABLE_METAX_API
+        GET(INFINI_DEVICE_METAX, metax)
+#endif
+#ifdef ENABLE_MOORE_API
+        GET(INFINI_DEVICE_MOORE, moore)
 #endif
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
@@ -118,6 +136,12 @@ __INFINI_C infiniStatus_t infiniopSigmoid(
 #ifdef ENABLE_HYGON_API
         CALCULATE(INFINI_DEVICE_HYGON, nvidia);
 #endif
+#ifdef ENABLE_METAX_API
+        CALCULATE(INFINI_DEVICE_METAX, metax);
+#endif
+#ifdef ENABLE_MOORE_API
+        CALCULATE(INFINI_DEVICE_MOORE, moore);
+#endif
 
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
@@ -153,6 +177,12 @@ infiniopDestroySigmoidDescriptor(infiniopSigmoidDescriptor_t desc) {
 #endif
 #ifdef ENABLE_HYGON_API
         DELETE(INFINI_DEVICE_HYGON, nvidia);
+#endif
+#ifdef ENABLE_METAX_API
+        DELETE(INFINI_DEVICE_METAX, metax);
+#endif
+#ifdef ENABLE_MOORE_API
+        DELETE(INFINI_DEVICE_MOORE, moore);
 #endif
 
     default:

--- a/test/infiniop/gelu.py
+++ b/test/infiniop/gelu.py
@@ -89,7 +89,7 @@ def test(
         input_stride is not None or output_stride is not None
     ):
         return
-    if device == InfiniDeviceEnum.CAMBRICON and dtype == InfiniDtype.F64:
+    if device in (InfiniDeviceEnum.CAMBRICON, InfiniDeviceEnum.MOORE) and dtype == InfiniDtype.F64:
         return
 
     input = TestTensor(shape, input_stride, dtype, device)


### PR DESCRIPTION
moore
<img width="2284" height="248" alt="image" src="https://github.com/user-attachments/assets/ae6244a4-41d4-4845-a7c6-66c61edfdc34" />
<img width="2252" height="274" alt="image" src="https://github.com/user-attachments/assets/d71f8fcf-8123-45a5-a91b-1b40a5c9d831" />
<img width="2278" height="270" alt="image" src="https://github.com/user-attachments/assets/5aee0ff7-dccf-4618-9b4a-ae6171447798" />

metax-maca
<img width="2282" height="272" alt="image" src="https://github.com/user-attachments/assets/369f8324-9eb0-4014-8bf1-0d6e17e2d1ae" />
<img width="2240" height="156" alt="image" src="https://github.com/user-attachments/assets/399ca7fd-7e5d-4a20-9421-3d81703e1a9a" />
<img width="2290" height="276" alt="image" src="https://github.com/user-attachments/assets/afd8b0e8-0399-45da-90b7-a7d08dcc68fc" />

metax-hpcc
<img width="2328" height="264" alt="image" src="https://github.com/user-attachments/assets/8f7d9f49-9949-4a18-8b4a-a92ade5c0db0" />
<img width="2300" height="270" alt="image" src="https://github.com/user-attachments/assets/c8e66ec1-4e32-40e2-a800-89e70b864de2" />
<img width="2304" height="278" alt="image" src="https://github.com/user-attachments/assets/256d4803-ebd5-4fd4-9a25-a81ec9ac397c" />

