### PR TITLE
issue/1386 - feat: support Nvidia, Moore, Iluvatar, MetaX, Ascend, Cambricon, hygon, T-Head runtime with InfiniRT

### DIFF
--- a/python/infinicore/_preload.py
+++ b/python/infinicore/_preload.py
@@ -6,7 +6,6 @@ import os
 import sys
 from typing import Iterable, List
 
-
 _PRELOADED_HANDLES: List[ctypes.CDLL] = []
 
 
@@ -98,9 +97,7 @@ def _import_extension_global(module_name: str, path: str) -> None:
             raise
 
     module_path = getattr(module, "__file__", None) or path
-    _PRELOADED_HANDLES.append(
-        ctypes.CDLL(module_path, mode=ctypes.RTLD_GLOBAL)
-    )
+    _PRELOADED_HANDLES.append(ctypes.CDLL(module_path, mode=ctypes.RTLD_GLOBAL))
 
 
 def preload_flash_attn() -> None:

--- a/src/bridge/infini/rt.hpp
+++ b/src/bridge/infini/rt.hpp
@@ -33,6 +33,8 @@ inline constexpr ::infini::rt::Device::Type translate_to(infiniDevice_t device) 
         return ::infini::rt::Device::Type::kIluvatar;
     case INFINI_DEVICE_HYGON:
         return ::infini::rt::Device::Type::kHygon;
+    case INFINI_DEVICE_ALI:
+        return ::infini::rt::Device::Type::kThead;
     default:
         return ::infini::rt::Device::Type::kCount;
     }
@@ -56,6 +58,8 @@ inline constexpr infiniDevice_t translate_from(::infini::rt::Device::Type device
         return INFINI_DEVICE_ILUVATAR;
     case ::infini::rt::Device::Type::kHygon:
         return INFINI_DEVICE_HYGON;
+    case ::infini::rt::Device::Type::kThead:
+        return INFINI_DEVICE_ALI;
     default:
         return INFINI_DEVICE_TYPE_COUNT;
     }

--- a/src/infinicore/context/context_impl.cc
+++ b/src/infinicore/context/context_impl.cc
@@ -90,15 +90,18 @@ void ContextImpl::initializeRuntime() {
 ContextImpl::ContextImpl() {
     initializeRuntime<Device::Type::CPU>();
     initializeRuntime<Device::Type::NVIDIA>();
+    initializeRuntime<Device::Type::CAMBRICON>();
+    initializeRuntime<Device::Type::ASCEND>();
+    initializeRuntime<Device::Type::METAX>();
+    initializeRuntime<Device::Type::MOORE>();
     initializeRuntime<Device::Type::ILUVATAR>();
     initializeRuntime<Device::Type::HYGON>();
-    initializeRuntime<Device::Type::ASCEND>();
+    initializeRuntime<Device::Type::ALI>();
 
     if (current_runtime_ == nullptr && !runtime_table_[static_cast<int>(Device::Type::CPU)].empty()) {
         current_runtime_ = runtime_table_[static_cast<int>(Device::Type::CPU)][0].get();
     }
 }
-
 namespace context {
 
 void setDevice(Device device) {

--- a/xmake.lua
+++ b/xmake.lua
@@ -306,6 +306,71 @@ local function get_infinirt_root()
     return nil
 end
 
+local function add_moore_runtime_sdk_dirs()
+    if not has_config("moore-gpu") then
+        return
+    end
+    local musa_root = os.getenv("MUSA_ROOT") or os.getenv("MUSA_HOME") or os.getenv("MUSA_PATH") or "/usr/local/musa"
+    add_includedirs(path.join(musa_root, "include"))
+    add_linkdirs(
+        path.join(musa_root, "lib"),
+        path.join(musa_root, "lib64"))
+    add_rpathdirs(path.join(musa_root, "lib"), path.join(musa_root, "lib64"))
+end
+
+local function add_metax_runtime_sdk_dirs()
+    if not has_config("metax-gpu") then
+        return
+    end
+    local maca_root = os.getenv("MACA_PATH") or os.getenv("MACA_HOME") or os.getenv("MACA_ROOT") or "/opt/maca"
+    add_includedirs(path.join(maca_root, "include"))
+    add_linkdirs(path.join(maca_root, "lib"), path.join(maca_root, "lib64"))
+    add_rpathdirs(path.join(maca_root, "lib"), path.join(maca_root, "lib64"))
+end
+
+local function add_ascend_runtime_sdk_dirs()
+    if not has_config("ascend-npu") then
+        return
+    end
+    local ascend_home = os.getenv("ASCEND_HOME") or os.getenv("ASCEND_TOOLKIT_HOME") or "/usr/local/Ascend/ascend-toolkit/latest"
+    add_includedirs(path.join(ascend_home, "include"), path.join(ascend_home, "include", "aclnn"))
+    add_linkdirs(path.join(ascend_home, "lib64"))
+    add_rpathdirs(path.join(ascend_home, "lib64"))
+end
+
+local function get_ali_cuda_root()
+    local ali_cuda_root = os.getenv("ALI_CUDA_ROOT") or os.getenv("PPU_CUDA_ROOT")
+    local ppu_sdk_root = os.getenv("PPU_SDK_ROOT")
+    if (not ali_cuda_root or ali_cuda_root == "") and ppu_sdk_root and ppu_sdk_root ~= "" then
+        ali_cuda_root = path.join(ppu_sdk_root, "CUDA_SDK")
+    end
+    return ali_cuda_root or get_config("cuda") or "/usr/local/PPU_SDK/CUDA_SDK"
+end
+
+local function add_ali_runtime_sdk_dirs()
+    if not has_config("ali-ppu") then
+        return
+    end
+    local ali_cuda_root = get_ali_cuda_root()
+    for _, include_dir in ipairs({
+        path.join(ali_cuda_root, "include"),
+        path.join(ali_cuda_root, "targets", "x86_64-linux", "include"),
+    }) do
+        if os.isdir(include_dir) then
+            add_includedirs(include_dir)
+        end
+    end
+    for _, link_dir in ipairs({
+        path.join(ali_cuda_root, "lib64"),
+        path.join(ali_cuda_root, "targets", "x86_64-linux", "lib"),
+    }) do
+        if os.isdir(link_dir) then
+            add_linkdirs(link_dir)
+            add_rpathdirs(link_dir)
+        end
+    end
+end
+
 local function get_infiniops_cuda_architectures()
     local arch_opt = get_config("cuda_arch")
     if not arch_opt or arch_opt == "" then
@@ -508,6 +573,10 @@ target_end()
 target("infiniop")
     set_kind("shared")
     add_external_infinirt()
+    add_moore_runtime_sdk_dirs()
+    add_metax_runtime_sdk_dirs()
+    add_ascend_runtime_sdk_dirs()
+    add_ali_runtime_sdk_dirs()
 
     local public_cuda_root = get_config("cuda") or os.getenv("CUDA_HOME") or os.getenv("CUDA_PATH")
     if public_cuda_root and public_cuda_root ~= "" then
@@ -529,6 +598,9 @@ target("infiniop")
         end
     elseif has_config("nv-gpu") then
         add_includedirs(path.join("/usr/local/cuda", "include"))
+    elseif has_config("iluvatar-gpu") then
+        add_includedirs(path.join("/usr/local/corex", "include"))
+        add_linkdirs(path.join("/usr/local/corex", "lib64"))
     end
 
     if has_config("cpu") then
@@ -625,6 +697,7 @@ target("infiniccl")
 
     add_files("src/infiniccl/*.cc")
     add_installfiles("include/infiniccl.h", {prefixdir = "include"})
+    add_installfiles("include/infinirt.h", {prefixdir = "include"})
 
     set_installdir(os.getenv("INFINI_ROOT") or (os.getenv(is_host("windows") and "HOMEPATH" or "HOME") .. "/.infini"))
 target_end()
@@ -666,8 +739,13 @@ target("infinicore_cpp_api")
     end
     add_includedirs(INFINI_ROOT.."/include", { public = true })
     add_external_infinirt()
-    if has_config("nv-gpu") then
-        local cuda_root = os.getenv("CUDA_HOME") or os.getenv("CUDA_PATH") or get_config("cuda") or "/usr/local/cuda"
+    add_moore_runtime_sdk_dirs()
+    add_metax_runtime_sdk_dirs()
+    add_ascend_runtime_sdk_dirs()
+    add_ali_runtime_sdk_dirs()
+    if has_config("nv-gpu") or has_config("iluvatar-gpu") then
+        local default_cuda_root = has_config("iluvatar-gpu") and "/usr/local/corex" or "/usr/local/cuda"
+        local cuda_root = os.getenv("CUDA_HOME") or os.getenv("CUDA_PATH") or get_config("cuda") or default_cuda_root
         add_includedirs(cuda_root .. "/include")
     end
     if has_config("infiniops") then
@@ -910,6 +988,7 @@ target("infinicore_cpp_api")
     add_installfiles("include/infinicore/(**/*.hpp)",{prefixdir = "include/infinicore"})
     add_installfiles("include/infinicore.h",          {prefixdir = "include"})
     add_installfiles("include/infinicore.hpp",        {prefixdir = "include"})
+    add_installfiles("include/infinirt.h",            {prefixdir = "include"})
     after_build(function (target) print(YELLOW .. "[Congratulations!] Now you can install the libraries with \"xmake install\"" .. NC) end)
 target_end()
 
@@ -932,6 +1011,14 @@ target("_infinicore")
     local INFINI_ROOT = os.getenv("INFINI_ROOT") or (os.getenv(is_host("windows") and "HOMEPATH" or "HOME") .. "/.infini")
     add_includedirs(INFINI_ROOT.."/include", { public = true })
     add_external_infinirt()
+    add_moore_runtime_sdk_dirs()
+    add_metax_runtime_sdk_dirs()
+    add_ascend_runtime_sdk_dirs()
+    add_ali_runtime_sdk_dirs()
+    if has_config("iluvatar-gpu") then
+        local cuda_root = os.getenv("CUDA_HOME") or os.getenv("CUDA_PATH") or get_config("cuda") or "/usr/local/corex"
+        add_cxxflags("-idirafter", cuda_root .. "/include", {force = true})
+    end
 
     add_linkdirs(INFINI_ROOT.."/lib")
     add_links("infiniop", "infiniccl")

--- a/xmake/ali.lua
+++ b/xmake/ali.lua
@@ -80,6 +80,7 @@ target_end()
 
 target("infinirt-ali")
     set_kind("static")
+    set_default(false)
     add_deps("infini-utils")
     on_install(function (target) end)
 

--- a/xmake/ascend.lua
+++ b/xmake/ascend.lua
@@ -80,6 +80,7 @@ target_end()
 
 target("infinirt-ascend")
     set_kind("static")
+    set_default(false)
     set_languages("cxx17")
     on_install(function (target) end)
     add_deps("infini-utils")

--- a/xmake/bang.lua
+++ b/xmake/bang.lua
@@ -54,6 +54,7 @@ target_end()
 
 target("infinirt-cambricon")
     set_kind("static")
+    set_default(false)
     add_deps("infini-utils")
     set_languages("cxx17")
     on_install(function (target) end)

--- a/xmake/iluvatar.lua
+++ b/xmake/iluvatar.lua
@@ -81,6 +81,7 @@ target_end()
 
 target("infinirt-iluvatar")
     set_kind("static")
+    set_default(false)
     add_deps("infini-utils")
     on_install(function (target) end)
 

--- a/xmake/metax.lua
+++ b/xmake/metax.lua
@@ -147,6 +147,7 @@ target_end()
 
 target("infinirt-metax")
     set_kind("static")
+    set_default(false)
     set_languages("cxx17")
     on_install(function (target) end)
     add_deps("infini-utils")

--- a/xmake/moore.lua
+++ b/xmake/moore.lua
@@ -70,6 +70,7 @@ target_end()
 
 target("infinirt-moore")
     set_kind("static")
+    set_default(false)
     set_languages("cxx17")
     on_install(function (target) end)
     add_deps("infini-utils")


### PR DESCRIPTION
This PR replaces the InfiniCore runtime dependency with InfiniRT. The changes are integrated with InfiniLM and validated through inference tests across multiple accelerator backends.

### Supported backends
- Nvidia
- Ascend
- Cambricon
- Moore
- Iluvatar
- MetaX
- hygon
- T-Head

### A100：
<img width="1343" height="1193" alt="image" src="https://github.com/user-attachments/assets/d27d1e25-c032-4ce6-9f99-9da4ec952267" />


### Cambricon MLU590：
<img width="1425" height="1172" alt="image" src="https://github.com/user-attachments/assets/021aae00-51f6-4d79-885e-02391745ecf1" />
备注：当前只支持单卡，main 分支只支持单卡


### Ascend 910b4：
<img width="1338" height="1170" alt="image" src="https://github.com/user-attachments/assets/d1871243-5db6-478d-b525-8fa269d2e11d" />


### Hygon BW1000：
<img width="1323" height="1152" alt="image" src="https://github.com/user-attachments/assets/444b106d-95b8-4564-8508-db46b97555f7" />


### MTT S5000：
<img width="1458" height="1269" alt="image" src="https://github.com/user-attachments/assets/eedb3b96-e684-4c92-8c72-5cc0d05a5aba" />


### METAX C550：
<img width="1380" height="1320" alt="image" src="https://github.com/user-attachments/assets/94f820a9-142a-4b58-960d-2a1d87174b58" />


### PPU ZW810E：
<img width="1452" height="1098" alt="image" src="https://github.com/user-attachments/assets/bb74e8fe-712f-4136-a4cf-e55f9dbc0e46" />


### Iluvatar TG200：
<img width="1329" height="1233" alt="image" src="https://github.com/user-attachments/assets/9b9c60af-e043-4541-ab38-3fe79bd31a59" />



