### PR TITLE
feat(cambricon): enable TaskTopo graph capture

### DIFF
--- a/src/infinicore/context/allocators/pinnable_block_allocator.cc
+++ b/src/infinicore/context/allocators/pinnable_block_allocator.cc
@@ -65,6 +65,9 @@ std::byte *PinnableBlockAllocator::allocate(size_t size) {
                     cls.free_blocks.pop_back();
                     block->in_use = true;
                     block->use_count = 1;
+                    // A cached eager block may become graph-visible when reused
+                    // in pin mode. Freeze it so trim cannot invalidate that pointer.
+                    block->frozen = block->frozen || pinned_mode_;
                     return reinterpret_cast<std::byte *>(block->ptr);
                 }
             }

--- a/src/infiniop/devices/bang/common_bang.h
+++ b/src/infiniop/devices/bang/common_bang.h
@@ -16,6 +16,31 @@ constexpr size_t ALIGN_SIZE = 128;
 
 namespace device::bang {
 
+// Preserve eager synchronization without inserting an invalid queue sync into
+// a CNRT TaskTopo capture. Captured work remains ordered by the queue itself.
+inline bool isQueueCapturing(cnrtQueue_t queue) {
+    cnrtQueueCaptureStatus_t status = cnrtQueueCaptureStatusNone;
+    uint64_t capture_id = 0;
+    cnrtTaskTopo_t task_topo = nullptr;
+    const cnrtTaskTopoNode_t *dependencies = nullptr;
+    size_t num_dependencies = 0;
+    auto ret = cnrtQueueGetCaptureInfo(
+        queue,
+        &status,
+        &capture_id,
+        &task_topo,
+        &dependencies,
+        &num_dependencies);
+    return ret == cnrtSuccess && status == cnrtQueueCaptureStatusActive;
+}
+
+inline infiniStatus_t syncQueueIfNotCapturing(cnrtQueue_t queue) {
+    if (!isQueueCapturing(queue)) {
+        CHECK_INTERNAL(cnrtQueueSync(queue), cnrtSuccess);
+    }
+    return INFINI_STATUS_SUCCESS;
+}
+
 class Handle::Internal {
     Pool<cnnlHandle_t> cnnl_handles;
 

--- a/src/infiniop/elementwise/bang/elementwise_bang.h
+++ b/src/infiniop/elementwise/bang/elementwise_bang.h
@@ -52,7 +52,6 @@ struct DeviceImpl::Opaque {
         }
 
         // Device pointers for metadata
-        const void **d_inputs_arr = nullptr;
         const bool *d_input_contiguous = nullptr;
         const bool *d_input_broadcasted = nullptr;
         const size_t *d_output_shape = nullptr;
@@ -60,11 +59,14 @@ struct DeviceImpl::Opaque {
         const size_t *d_input_shapes = nullptr;
         const ptrdiff_t *d_input_strides = nullptr;
 
-        // Copy metadata to device and setup pointers
-        CHECK_STATUS(infoToDevice<N>(info, workspace, inputs.data(), d_inputs_arr,
+        // inputs is a temporary host vector, so its pointer array cannot be a
+        // replay-time H2D source. Capture the stable device pointers as kernel
+        // arguments and reserve workspace only for descriptor-owned metadata.
+        CHECK_STATUS(infoToDevice<N>(info, workspace,
                                      d_input_contiguous, d_input_broadcasted,
                                      d_output_shape, d_output_strides,
-                                     d_input_shapes, d_input_strides));
+                                     d_input_shapes, d_input_strides,
+                                     queue));
 
         // Launch the elementwise kernel
         Op::template launch<Tdata>(
@@ -78,13 +80,13 @@ struct DeviceImpl::Opaque {
             reinterpret_cast<const void *>(d_output_strides),
             reinterpret_cast<const void *>(d_input_strides),
             output,
-            reinterpret_cast<const void *const *>(d_inputs_arr),
+            inputs.data(),
             queue,
             internal,
             args...);
 
         // Synchronize queue to ensure completion
-        CNRT_CHECK(cnrtQueueSync(queue));
+        CHECK_STATUS(device::bang::syncQueueIfNotCapturing(queue));
 
         return INFINI_STATUS_SUCCESS;
     }
@@ -97,8 +99,6 @@ private:
      *
      * @param info                   Elementwise operation metadata.
      * @param workspace              Device workspace memory.
-     * @param h_inputs_arr           Host array of input pointers.
-     * @param d_inputs_arr           Output reference to device input pointers.
      * @param d_input_contiguous     Output reference to contiguous flags.
      * @param d_input_broadcasted    Output reference to broadcast flags.
      * @param d_output_shape         Output reference to output shape.
@@ -111,27 +111,30 @@ private:
     infiniStatus_t infoToDevice(
         const op::elementwise::ElementwiseInfo &info,
         void *workspace,
-        const void *const *h_inputs_arr,
-        const void **&d_inputs_arr,
         const bool *&d_input_contiguous,
         const bool *&d_input_broadcasted,
         const size_t *&d_output_shape,
         const ptrdiff_t *&d_output_strides,
         const size_t *&d_input_shapes,
-        const ptrdiff_t *&d_input_strides) const {
+        const ptrdiff_t *&d_input_strides,
+        cnrtQueue_t queue) const {
 
         constexpr auto input_size = N;
         const auto ndim = info.getNdim();
-        constexpr auto input_arr_size = N * sizeof(*h_inputs_arr);
         const int8_t *info_meta_start = info.getMetaStart();
-        const int8_t *d_meta_start = reinterpret_cast<int8_t *>(workspace) + input_arr_size;
+        const int8_t *d_meta_start = reinterpret_cast<int8_t *>(workspace);
 
-        // Copy input pointer array and metadata to device
-        CNRT_CHECK(cnrtMemcpy(workspace, (void *)h_inputs_arr, input_arr_size, cnrtMemcpyHostToDev));
-        CNRT_CHECK(cnrtMemcpy((void *)d_meta_start, (void *)info_meta_start, info.getMetaMemSize(), cnrtMemcpyHostToDev));
+        // Record the metadata copy in TaskTopo so graph workspaces can be
+        // shared safely across shapes. The descriptor owns the host metadata
+        // for the lifetime of the captured graph.
+        CNRT_CHECK(cnrtMemcpyAsync_V2(
+            (void *)d_meta_start,
+            (void *)info_meta_start,
+            info.getMetaMemSize(),
+            queue,
+            cnrtMemcpyHostToDev));
 
         // Setup pointers to device memory regions
-        d_inputs_arr = reinterpret_cast<const void **>(workspace);
         d_output_shape = reinterpret_cast<const size_t *>(d_meta_start);
         d_output_strides = reinterpret_cast<const ptrdiff_t *>(d_output_shape + ndim);
         d_input_shapes = reinterpret_cast<const size_t *>(d_output_strides + ndim);

--- a/src/infiniop/elementwise/bang/elementwise_bang_api.h
+++ b/src/infiniop/elementwise/bang/elementwise_bang_api.h
@@ -68,7 +68,8 @@ public:
     auto info_result = op::elementwise::ElementwiseInfo::create(OUT_DESC, INPUT_DESC_VEC);   \
     CHECK_RESULT(info_result);                                                               \
     auto info = info_result.take();                                                          \
-    auto workspace_size = info.getMetaMemSize() + info.getInputSize() * sizeof(void *);      \
+    /* Input pointers are kernel arguments; workspace contains metadata only. */             \
+    auto workspace_size = info.getMetaMemSize();                                             \
                                                                                              \
     auto device_impl_result = op::elementwise::bang::DeviceImpl::create(HANDLE->internal()); \
     CHECK_RESULT(device_impl_result);                                                        \

--- a/src/infiniop/elementwise/bang/elementwise_bang_kernel.h
+++ b/src/infiniop/elementwise/bang/elementwise_bang_kernel.h
@@ -166,13 +166,19 @@ __mlu_global__ void elementwiseKernel(
     const ptrdiff_t *output_strides,
     const ptrdiff_t *input_strides,
     Tdata *output,
-    const void *const *inputs,
+    const void *input0,
+    const void *input1,
     Args... args) {
 
+    static_assert(N <= 2, "BANG elementwise kernel supports at most two inputs.");
+
+    // Keep input pointers in kernel parameters so graph capture does not depend
+    // on a device-side pointer array refreshed by H2D copies.
     // Cast input pointers to the correct type
     Tdata *typed_inputs[N];
-    for (size_t i = 0; i < N; ++i) {
-        typed_inputs[i] = reinterpret_cast<Tdata *>(const_cast<void *>(inputs[i]));
+    typed_inputs[0] = reinterpret_cast<Tdata *>(const_cast<void *>(input0));
+    if constexpr (N > 1) {
+        typed_inputs[1] = reinterpret_cast<Tdata *>(const_cast<void *>(input1));
     }
 
     // Calculate workload per task
@@ -264,7 +270,10 @@ void launchElementwiseKernelWrapper(
         input_contiguous, input_broadcasted,
         output_shape, input_shapes,
         output_strides, input_strides,
-        output, inputs, args...);
+        output,
+        inputs[0],
+        N > 1 ? inputs[1] : nullptr,
+        args...);
 }
 
 /**

--- a/src/infiniop/ops/add_rms_norm/bang/add_rms_norm_bang.mlu
+++ b/src/infiniop/ops/add_rms_norm/bang/add_rms_norm_bang.mlu
@@ -373,7 +373,7 @@ static infiniStatus_t launchAddRMSNorm(
             stride_b_nhead,
             epsilon);
     }
-    cnrtQueueSync(queue);
+    CHECK_STATUS(device::bang::syncQueueIfNotCapturing(queue));
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/asum/bang/asum_bang.mlu
+++ b/src/infiniop/ops/asum/bang/asum_bang.mlu
@@ -57,7 +57,7 @@ infiniStatus_t calculateAsum(
             result);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 
     return INFINI_STATUS_SUCCESS;
 }

--- a/src/infiniop/ops/axpy/bang/axpy_bang.mlu
+++ b/src/infiniop/ops/axpy/bang/axpy_bang.mlu
@@ -64,7 +64,7 @@ infiniStatus_t calculateAxpy(
             incy);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 
     return INFINI_STATUS_SUCCESS;
 }

--- a/src/infiniop/ops/blas_amax/bang/blas_amax_bang.mlu
+++ b/src/infiniop/ops/blas_amax/bang/blas_amax_bang.mlu
@@ -58,7 +58,7 @@ infiniStatus_t calculateBlasAmax(
             result);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 
     return INFINI_STATUS_SUCCESS;
 }

--- a/src/infiniop/ops/blas_amin/bang/blas_amin_bang.mlu
+++ b/src/infiniop/ops/blas_amin/bang/blas_amin_bang.mlu
@@ -58,7 +58,7 @@ infiniStatus_t calculateBlasAmin(
             result);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 
     return INFINI_STATUS_SUCCESS;
 }

--- a/src/infiniop/ops/blas_copy/bang/blas_copy_bang.mlu
+++ b/src/infiniop/ops/blas_copy/bang/blas_copy_bang.mlu
@@ -59,7 +59,7 @@ infiniStatus_t calculateBlasCopy(
             incy);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/blas_dot/bang/blas_dot_bang.mlu
+++ b/src/infiniop/ops/blas_dot/bang/blas_dot_bang.mlu
@@ -63,7 +63,7 @@ infiniStatus_t calculateBlasDot(
             result);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 
     return INFINI_STATUS_SUCCESS;
 }

--- a/src/infiniop/ops/causal_softmax/bang/causal_softmax_bang.mlu
+++ b/src/infiniop/ops/causal_softmax/bang/causal_softmax_bang.mlu
@@ -140,7 +140,7 @@ void causalSoftmaxUnion(void *workspace, int core_per_cluster, int cluster_count
         info->y_stride_b, info->y_stride_i, info->y_stride_j,
         info->x_stride_b, info->x_stride_i, info->x_stride_j);
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 }
 
 namespace op::causal_softmax::bang {

--- a/src/infiniop/ops/conv/bang/conv_bang.cc
+++ b/src/infiniop/ops/conv/bang/conv_bang.cc
@@ -338,7 +338,7 @@ infiniStatus_t Descriptor::calculate(
                 _opaque->transpose_workspace_size));
             return INFINI_STATUS_SUCCESS;
         }));
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/embedding/bang/embedding_bang.mlu
+++ b/src/infiniop/ops/embedding/bang/embedding_bang.mlu
@@ -76,7 +76,7 @@ static infiniStatus_t launchEmbedding(
         num_indices,
         embedding_dim,
         vocab_size);
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/gemm/bang/gemm_bang.cc
+++ b/src/infiniop/ops/gemm/bang/gemm_bang.cc
@@ -148,7 +148,7 @@ infiniStatus_t Descriptor::calculate(
                 workspace_size));
             return INFINI_STATUS_SUCCESS;
         }));
-    cnrtQueueSync((cnrtQueue_t)stream);
+    CHECK_STATUS(device::bang::syncQueueIfNotCapturing((cnrtQueue_t)stream));
 
     return INFINI_STATUS_SUCCESS;
 }

--- a/src/infiniop/ops/layer_norm/bang/layer_norm_bang.mlu
+++ b/src/infiniop/ops/layer_norm/bang/layer_norm_bang.mlu
@@ -188,11 +188,12 @@ void launchLayerNorm(
     ptrdiff_t *mlu_std_deviation_strides = mlu_standardization_strides + info.ndim;
     ptrdiff_t *mlu_input_strides = mlu_std_deviation_strides + (info.ndim - 1);
 
-    CNRT_CHECK(cnrtMemcpyAsync(mlu_shape, const_cast<size_t *>(info.input_shape.data()), info.ndim * sizeof(size_t), queue, cnrtMemcpyHostToDev));
-    CNRT_CHECK(cnrtMemcpyAsync(mlu_output_strides, const_cast<ptrdiff_t *>(info.output_strides.data()), info.ndim * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
-    CNRT_CHECK(cnrtMemcpyAsync(mlu_standardization_strides, const_cast<ptrdiff_t *>(info.input_standardization_strides.data()), info.ndim * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
-    CNRT_CHECK(cnrtMemcpyAsync(mlu_std_deviation_strides, const_cast<ptrdiff_t *>(info.input_std_deviation_strides.data()), (info.ndim - 1) * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
-    CNRT_CHECK(cnrtMemcpyAsync(mlu_input_strides, const_cast<ptrdiff_t *>(info.input_strides.data()), info.ndim * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
+    // During capture, TaskTopo records these metadata copies before the kernel.
+    CNRT_CHECK(cnrtMemcpyAsync_V2(mlu_shape, const_cast<size_t *>(info.input_shape.data()), info.ndim * sizeof(size_t), queue, cnrtMemcpyHostToDev));
+    CNRT_CHECK(cnrtMemcpyAsync_V2(mlu_output_strides, const_cast<ptrdiff_t *>(info.output_strides.data()), info.ndim * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
+    CNRT_CHECK(cnrtMemcpyAsync_V2(mlu_standardization_strides, const_cast<ptrdiff_t *>(info.input_standardization_strides.data()), info.ndim * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
+    CNRT_CHECK(cnrtMemcpyAsync_V2(mlu_std_deviation_strides, const_cast<ptrdiff_t *>(info.input_std_deviation_strides.data()), (info.ndim - 1) * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
+    CNRT_CHECK(cnrtMemcpyAsync_V2(mlu_input_strides, const_cast<ptrdiff_t *>(info.input_strides.data()), info.ndim * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
 
     layerNormKernel<Tdata, Tweight><<<kernel_dim, cnrtFuncTypeUnion1, queue>>>(
         reinterpret_cast<Tdata *>(output),
@@ -213,7 +214,7 @@ void launchLayerNorm(
         info.bias_exist ? info.bias_strides.back() : 0,
         info.eps,
         info.bias_exist);
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 }
 
 namespace op::layer_norm::bang {

--- a/src/infiniop/ops/nrm2/bang/nrm2_bang.mlu
+++ b/src/infiniop/ops/nrm2/bang/nrm2_bang.mlu
@@ -58,7 +58,7 @@ infiniStatus_t calculateNrm2(
             result);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 
     return INFINI_STATUS_SUCCESS;
 }

--- a/src/infiniop/ops/paged_attention/bang/paged_attention_bang.mlu
+++ b/src/infiniop/ops/paged_attention/bang/paged_attention_bang.mlu
@@ -247,7 +247,7 @@ infiniStatus_t launchPagedAttention(
         info.o_stride,
         info.block_table_batch_stride,
         info.cache_lens_stride);
-    cnrtQueueSync(queue);
+    CHECK_STATUS(device::bang::syncQueueIfNotCapturing(queue));
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/paged_attention_prefill/bang/paged_attention_prefill_bang.mlu
+++ b/src/infiniop/ops/paged_attention_prefill/bang/paged_attention_prefill_bang.mlu
@@ -276,7 +276,7 @@ infiniStatus_t launchPagedAttentionPrefill(
         info.v_head_stride,
         info.o_stride,
         info.o_head_stride);
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/paged_caching/bang/paged_caching_bang.mlu
+++ b/src/infiniop/ops/paged_caching/bang/paged_caching_bang.mlu
@@ -88,7 +88,7 @@ infiniStatus_t launchPagedCaching(
         info.v_cache_head_stride,
         info.k_cache_slot_stride,
         info.v_cache_slot_stride);
-    cnrtQueueSync(queue);
+    CHECK_STATUS(device::bang::syncQueueIfNotCapturing(queue));
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/random_sample/bang/random_sample_kernel.mlu
+++ b/src/infiniop/ops/random_sample/bang/random_sample_kernel.mlu
@@ -545,7 +545,7 @@ struct Algo {
             return INFINI_STATUS_BAD_TENSOR_DTYPE;
         }
 
-        cnrtQueueSync(queue);
+        device::bang::syncQueueIfNotCapturing(queue);
         return INFINI_STATUS_SUCCESS;
     }
 
@@ -618,7 +618,7 @@ struct Algo {
         } else {
             return INFINI_STATUS_BAD_TENSOR_DTYPE;
         }
-        cnrtQueueSync(queue);
+        device::bang::syncQueueIfNotCapturing(queue);
 
         return INFINI_STATUS_SUCCESS;
     }

--- a/src/infiniop/ops/rearrange/bang/rearrange_bang.mlu
+++ b/src/infiniop/ops/rearrange/bang/rearrange_bang.mlu
@@ -226,7 +226,7 @@ infiniStatus_t Descriptor::create(
                         dst_strides_32.size() * sizeof(int), queue, cnrtMemcpyHostToDev);
         cnrtMemcpyAsync(d_src_strides, src_strides_32.data(),
                         src_strides_32.size() * sizeof(int), queue, cnrtMemcpyHostToDev);
-        cnrtQueueSync(queue);
+        device::bang::syncQueueIfNotCapturing(queue);
         cnrtQueueDestroy(queue);
     }
 
@@ -292,7 +292,7 @@ infiniStatus_t Descriptor::calculate(
             static_cast<int>(meta.unit()));
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/rms_norm/bang/rms_norm_bang.mlu
+++ b/src/infiniop/ops/rms_norm/bang/rms_norm_bang.mlu
@@ -247,15 +247,15 @@ void rmsnormUnion(void *workspace, int core_per_cluster, int cluster_count, cnrt
     ptrdiff_t *mlu_x_strides = (ptrdiff_t *)tmp_stride;
     ptrdiff_t *mlu_y_strides = mlu_x_strides + ndim;
 
-    // Copy shape and stride information to device
-    CNRT_CHECK(cnrtMemcpyAsync(mlu_shape, const_cast<size_t *>(shape), ndim * sizeof(size_t), queue, cnrtMemcpyHostToDev)); // const not supported
-    CNRT_CHECK(cnrtMemcpyAsync(mlu_x_strides, const_cast<ptrdiff_t *>(x_strides), ndim * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
-    CNRT_CHECK(cnrtMemcpyAsync(mlu_y_strides, const_cast<ptrdiff_t *>(y_strides), ndim * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
+    // During capture, TaskTopo records these metadata copies before the kernel.
+    CNRT_CHECK(cnrtMemcpyAsync_V2(mlu_shape, const_cast<size_t *>(shape), ndim * sizeof(size_t), queue, cnrtMemcpyHostToDev)); // const not supported
+    CNRT_CHECK(cnrtMemcpyAsync_V2(mlu_x_strides, const_cast<ptrdiff_t *>(x_strides), ndim * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
+    CNRT_CHECK(cnrtMemcpyAsync_V2(mlu_y_strides, const_cast<ptrdiff_t *>(y_strides), ndim * sizeof(ptrdiff_t), queue, cnrtMemcpyHostToDev));
 
     // Launch kernel
     rmsnorm<T, Tw><<<kernel_dim, kernel_type, queue>>>(y_, x_, w_, mlu_shape, mlu_y_strides, mlu_x_strides, eps, ndim, dim_s);
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 }
 
 namespace op::rms_norm::bang {

--- a/src/infiniop/ops/rope/bang/rope_bang.mlu
+++ b/src/infiniop/ops/rope/bang/rope_bang.mlu
@@ -62,7 +62,7 @@ infiniStatus_t calculateRoPE(const RoPEInfo &info,
         info.x_stride_batch, info.x_stride_seqlen, info.x_stride_nhead,
         info.algo);
 
-    cnrtQueueSync(queue);
+    CHECK_STATUS(device::bang::syncQueueIfNotCapturing(queue));
 
     return INFINI_STATUS_SUCCESS;
 }

--- a/src/infiniop/ops/rot/bang/rot_bang.mlu
+++ b/src/infiniop/ops/rot/bang/rot_bang.mlu
@@ -66,7 +66,7 @@ infiniStatus_t calculateRot(
             s);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/rotg/bang/rotg_bang.mlu
+++ b/src/infiniop/ops/rotg/bang/rotg_bang.mlu
@@ -49,7 +49,7 @@ infiniStatus_t calculateRotg(
         c,
         s);
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/rotm/bang/rotm_bang.mlu
+++ b/src/infiniop/ops/rotm/bang/rotm_bang.mlu
@@ -62,7 +62,7 @@ infiniStatus_t calculateRotm(
             param);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/rotmg/bang/rotmg_bang.mlu
+++ b/src/infiniop/ops/rotmg/bang/rotmg_bang.mlu
@@ -52,7 +52,7 @@ infiniStatus_t calculateRotmg(
         y1,
         param);
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 
     return INFINI_STATUS_SUCCESS;
 }

--- a/src/infiniop/ops/scal/bang/scal_bang.mlu
+++ b/src/infiniop/ops/scal/bang/scal_bang.mlu
@@ -57,7 +57,7 @@ infiniStatus_t calculateScal(
             incx);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
 
     return INFINI_STATUS_SUCCESS;
 }

--- a/src/infiniop/ops/softmax/bang/softmax_bang.cc
+++ b/src/infiniop/ops/softmax/bang/softmax_bang.cc
@@ -89,7 +89,7 @@ infiniStatus_t Descriptor::calculate(
                 y));
             return INFINI_STATUS_SUCCESS;
         }));
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
     return INFINI_STATUS_SUCCESS;
 }
 

--- a/src/infiniop/ops/swap/bang/swap_bang.mlu
+++ b/src/infiniop/ops/swap/bang/swap_bang.mlu
@@ -59,7 +59,7 @@ infiniStatus_t calculateSwap(
             incy);
     }
 
-    cnrtQueueSync(queue);
+    device::bang::syncQueueIfNotCapturing(queue);
     return INFINI_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
Avoid queue synchronization while CNRT is capturing, while preserving the synchronous eager-execution contract outside capture.

Record descriptor-owned metadata with cnrtMemcpyAsync_V2 and pass temporary elementwise input pointers as kernel arguments so captured graphs can safely reuse frozen workspaces across batch shapes.

Initialize the Cambricon runtime and freeze cached allocations when they become visible to captured graphs so memory trimming cannot invalidate recorded pointers.