### PR TITLE
feat: add linear_packed variants with pre-transposed weight

### DIFF
--- a/include/infinicore/ops/linear.hpp
+++ b/include/infinicore/ops/linear.hpp
@@ -9,4 +9,11 @@ Tensor linear(Tensor input, Tensor weight, std::optional<Tensor> bias, float alp
 
 void linear_(Tensor out, Tensor input, Tensor weight, std::optional<Tensor> bias, float alpha = 1.0f);
 
+// Pre-packed weight variants: packed_weight is already [IC, OC] contiguous.
+// These skip the runtime weight->permute({1, 0}) call inside linear_.
+Tensor linear_packed(Tensor input, Tensor packed_weight,
+                     std::optional<Tensor> bias, float alpha = 1.0f);
+void linear_packed_(Tensor out, Tensor input, Tensor packed_weight,
+                    std::optional<Tensor> bias, float alpha = 1.0f);
+
 } // namespace infinicore::op

--- a/src/infinicore/ops/linear/linear.cc
+++ b/src/infinicore/ops/linear/linear.cc
@@ -57,4 +57,61 @@ void linear_(Tensor out,
           weight->permute({1, 0}), alpha, beta);
 }
 
+// --- Pre-packed weight variants ---
+// packed_weight layout: [in_features, out_features] (already transposed from [OC,IC])
+
+Tensor linear_packed(Tensor input,
+                     Tensor packed_weight,
+                     std::optional<Tensor> bias,
+                     float alpha) {
+
+    Size ndim = input->ndim();
+    // packed_weight shape is [IC, OC], so OC is dim 1
+    Size out_features = packed_weight->shape()[1];
+
+    auto output_shape = input->shape();
+    output_shape[ndim - 1] = out_features;
+    auto out = Tensor::empty(output_shape, input->dtype(), input->device());
+
+    linear_packed_(out, input, packed_weight, bias, alpha);
+    return out;
+}
+
+void linear_packed_(Tensor out,
+                    Tensor input,
+                    Tensor packed_weight,
+                    std::optional<Tensor> bias,
+                    float alpha) {
+
+    auto weight_shape = packed_weight->shape();
+    // packed_weight is [IC, OC] — already the layout GEMM expects
+    Size in_features  = weight_shape[0];
+    Size out_features = weight_shape[1];
+
+    Size ndim = input->ndim();
+    assert(out->ndim() == ndim);
+
+    Size N = 1;
+    auto input_shape = input->shape();
+    for (size_t i = 0; i < ndim - 1; ++i) {
+        N *= input_shape[i];
+    }
+
+    Tensor out_view = out->view({N, out_features});
+
+    // Add bias (same logic as linear_)
+    float beta = 0.0f;
+    if (bias.has_value()) {
+        rearrange_(out_view,
+                   bias.value()->as_strided({N, out_features}, {0, 1}));
+        beta = 1.0f;
+    }
+
+    // KEY: no weight->permute({1, 0}) here!
+    // packed_weight is already [IC, OC] contiguous.
+    gemm_(out_view,
+          input->view({N, in_features}),
+          packed_weight, alpha, beta);
+}
+
 } // namespace infinicore::op

--- a/src/infinicore/ops/linear/linear.cc
+++ b/src/infinicore/ops/linear/linear.cc
@@ -85,7 +85,7 @@ void linear_packed_(Tensor out,
 
     auto weight_shape = packed_weight->shape();
     // packed_weight is [IC, OC] — already the layout GEMM expects
-    Size in_features  = weight_shape[0];
+    Size in_features = weight_shape[0];
     Size out_features = weight_shape[1];
 
     Size ndim = input->ndim();


### PR DESCRIPTION
linear_packed() and linear_packed_() accept weight already in [IC, OC] layout, bypassing the permute({1, 0}) call inside linear_() to reduce runtime overhead when weights are pre-packed.