### PR TITLE
perf(nvidia): use cublasLt for bf16 gemm

### DIFF
--- a/src/infiniop/ops/gemm/nvidia/gemm_nvidia.cu
+++ b/src/infiniop/ops/gemm/nvidia/gemm_nvidia.cu
@@ -1,13 +1,127 @@
 #include "../../../devices/nvidia/nvidia_handle.cuh"
 #include "gemm_nvidia.cuh"
+#if !defined(ENABLE_ILUVATAR_API) && !defined(ENABLE_HYGON_API)
+#include <cublasLt.h>
+#endif
 
 namespace op::gemm::nvidia {
 
 struct Descriptor::Opaque {
     std::shared_ptr<device::nvidia::Handle::Internal> internal;
+#if !defined(ENABLE_ILUVATAR_API) && !defined(ENABLE_HYGON_API)
+    cublasLtHandle_t lt_handle = nullptr;
+    cublasLtMatmulDesc_t lt_desc = nullptr;
+    cublasLtMatrixLayout_t a_layout = nullptr;
+    cublasLtMatrixLayout_t b_layout = nullptr;
+    cublasLtMatrixLayout_t c_layout = nullptr;
+
+    void destroyLtDescriptors();
+    bool createBf16LtDescriptors(const MatmulInfo &info);
+#endif
 };
 
+#if !defined(ENABLE_ILUVATAR_API) && !defined(ENABLE_HYGON_API)
+static size_t ltLayoutRows(const BlasMatrix &matrix) {
+    return matrix.row_stride == 1 ? matrix.rows : matrix.cols;
+}
+
+static size_t ltLayoutCols(const BlasMatrix &matrix) {
+    return matrix.row_stride == 1 ? matrix.cols : matrix.rows;
+}
+
+static bool setLtLayoutBatch(cublasLtMatrixLayout_t layout, const BlasMatrix &matrix, size_t batch) {
+    int32_t batch_count = static_cast<int32_t>(batch);
+    int64_t stride = static_cast<int64_t>(matrix.stride);
+    return cublasLtMatrixLayoutSetAttribute(
+               layout, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+               &batch_count, sizeof(batch_count))
+            == CUBLAS_STATUS_SUCCESS
+        && cublasLtMatrixLayoutSetAttribute(
+               layout, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET,
+               &stride, sizeof(stride))
+               == CUBLAS_STATUS_SUCCESS;
+}
+
+void Descriptor::Opaque::destroyLtDescriptors() {
+    if (a_layout) {
+        cublasLtMatrixLayoutDestroy(a_layout);
+        a_layout = nullptr;
+    }
+    if (b_layout) {
+        cublasLtMatrixLayoutDestroy(b_layout);
+        b_layout = nullptr;
+    }
+    if (c_layout) {
+        cublasLtMatrixLayoutDestroy(c_layout);
+        c_layout = nullptr;
+    }
+    if (lt_desc) {
+        cublasLtMatmulDescDestroy(lt_desc);
+        lt_desc = nullptr;
+    }
+    if (lt_handle) {
+        cublasLtDestroy(lt_handle);
+        lt_handle = nullptr;
+    }
+}
+
+bool Descriptor::Opaque::createBf16LtDescriptors(const MatmulInfo &info) {
+    auto op_a = info.a_matrix.row_stride == 1 ? CUBLAS_OP_N : CUBLAS_OP_T;
+    auto op_b = info.b_matrix.row_stride == 1 ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+    if (cublasLtCreate(&lt_handle) != CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+    if (cublasLtMatmulDescCreate(&lt_desc, CUBLAS_COMPUTE_32F, CUDA_R_32F) != CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+    if (cublasLtMatmulDescSetAttribute(
+            lt_desc, CUBLASLT_MATMUL_DESC_TRANSA,
+            &op_a, sizeof(op_a))
+        != CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+    if (cublasLtMatmulDescSetAttribute(
+            lt_desc, CUBLASLT_MATMUL_DESC_TRANSB,
+            &op_b, sizeof(op_b))
+        != CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+
+    if (cublasLtMatrixLayoutCreate(
+            &a_layout, CUDA_R_16BF,
+            ltLayoutRows(info.a_matrix), ltLayoutCols(info.a_matrix),
+            info.a_matrix.ld())
+        != CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+    if (cublasLtMatrixLayoutCreate(
+            &b_layout, CUDA_R_16BF,
+            ltLayoutRows(info.b_matrix), ltLayoutCols(info.b_matrix),
+            info.b_matrix.ld())
+        != CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+    if (cublasLtMatrixLayoutCreate(
+            &c_layout, CUDA_R_16BF,
+            ltLayoutRows(info.c_matrix), ltLayoutCols(info.c_matrix),
+            info.c_matrix.ld())
+        != CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+
+    return setLtLayoutBatch(a_layout, info.a_matrix, info.batch)
+        && setLtLayoutBatch(b_layout, info.b_matrix, info.batch)
+        && setLtLayoutBatch(c_layout, info.c_matrix, info.batch);
+}
+#endif
+
 Descriptor::~Descriptor() {
+#if !defined(ENABLE_ILUVATAR_API) && !defined(ENABLE_HYGON_API)
+    if (_opaque) {
+        _opaque->destroyLtDescriptors();
+    }
+#endif
     delete _opaque;
 }
 
@@ -25,9 +139,17 @@ infiniStatus_t Descriptor::create(
     auto result = MatmulInfo::create(c_desc, a_desc, b_desc, MatrixLayout::COL_MAJOR);
     CHECK_RESULT(result);
 
+    auto info = result.take();
+    auto opaque = new Opaque{handle->internal()};
+#if !defined(ENABLE_ILUVATAR_API) && !defined(ENABLE_HYGON_API)
+    if (dtype == INFINI_DTYPE_BF16 && !opaque->createBf16LtDescriptors(info)) {
+        opaque->destroyLtDescriptors();
+    }
+#endif
+
     *desc_ptr = new Descriptor(
-        dtype, result.take(), 0,
-        new Opaque{handle->internal()},
+        dtype, info, 0,
+        opaque,
         handle->device, handle->device_id);
     return INFINI_STATUS_SUCCESS;
 }
@@ -85,6 +207,32 @@ infiniStatus_t Descriptor::calculate(
 
     auto op_a = _info.a_matrix.row_stride == 1 ? CUBLAS_OP_N : CUBLAS_OP_T;
     auto op_b = _info.b_matrix.row_stride == 1 ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+#if !defined(ENABLE_ILUVATAR_API) && !defined(ENABLE_HYGON_API)
+    if (_dtype == INFINI_DTYPE_BF16 && _opaque->lt_handle && _opaque->lt_desc
+        && _opaque->a_layout && _opaque->b_layout && _opaque->c_layout) {
+        auto lt_status = cublasLtMatmul(
+            _opaque->lt_handle,
+            _opaque->lt_desc,
+            &alpha,
+            a,
+            _opaque->a_layout,
+            b,
+            _opaque->b_layout,
+            &beta,
+            c,
+            _opaque->c_layout,
+            c,
+            _opaque->c_layout,
+            nullptr,
+            workspace,
+            workspace_size,
+            (cudaStream_t)stream);
+        if (lt_status == CUBLAS_STATUS_SUCCESS) {
+            return INFINI_STATUS_SUCCESS;
+        }
+    }
+#endif
 
     CHECK_STATUS(_opaque->internal->useCublas(
         (cudaStream_t)stream,

--- a/xmake/nvidia.lua
+++ b/xmake/nvidia.lua
@@ -37,7 +37,7 @@ target("infiniop-nvidia")
 
     set_policy("build.cuda.devlink", true)
     set_toolchains("cuda")
-    add_links("cudart", "cublas")
+    add_links("cudart", "cublas", "cublasLt")
     if has_config("cudnn") then
         add_links("cudnn")
     end


### PR DESCRIPTION
## Summary
- Add a NVIDIA BF16 GEMM path using cuBLASLt Matmul descriptors.
- Fall back to existing cublasGemmStridedBatchedEx when cuBLASLt cannot run the case.
- Link cublasLt explicitly for the NVIDIA backend because the new path directly references cublasLt symbols.

## Scope
- NVIDIA GEMM backend only.
- Build config change only adds the required cuBLASLt link dependency.

## Validation
- python3 scripts/format.py --check --c clang-format
- git diff --cached --check
- xmake f --nv-gpu=y --ccl=y --aten=y --graph=y --cuda=$CUDA_HOME --flash-attn=/workspace/InfiniCore/third_party/flash-attention -cv -y
- xmake build -y
- python3 test/infiniop/gemm.py --nvidia
## Performance

Benchmark on NVIDIA A100 with `OpenBMB/MiniCPM-V-2_6`, concurrency 20, 64 requests.

| Scenario | Method | Total time | RPS | Avg latency | TTFT | Time/token | Gen speed |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Multimodal | original cuBLAS GEMM | 135.42 s | 0.47 | 28.17 s | 2.32 s | 307.08 ms/token | 3.57 tokens/s |
| Multimodal | BF16 cuBLASLt GEMM | 8.17 s | 7.83 | 2.24 s | 0.45 s | 28.06 ms/token | 41.91 tokens/s |
| Text | original cuBLAS GEMM | 240.24 s | 0.27 | 57.82 s | 0.58 s | 228.73 ms/token | 4.38 tokens/s |
| Text | BF16 cuBLASLt GEMM | 25.81 s | 2.48 | 4.18 s | 0.17 s | 14.45 ms/token | 69.47 tokens/s |

Speedups:
- Multimodal: RPS +16.66x, avg latency -12.58x, time/token -10.94x, generation speed +11.74x.
- Text: RPS +9.19x, avg latency -13.83x, time/token -15.83x, generation speed +15.86x.

Note: output token counts differ between runs, so the normalized token metrics (`Time/token`, `Gen speed`) are the most comparable numbers.
