### PR TITLE
issue/1465 fix: adapt `Gemm` call to optional `c` API

### DIFF
--- a/src/infinicore/ops/gemm/gemm_infiniops.cc
+++ b/src/infinicore/ops/gemm/gemm_infiniops.cc
@@ -45,6 +45,7 @@ void run(void *planned_meta) {
         config,
         planned->a.tensor(planned->a_tensor),
         planned->b.tensor(planned->b_tensor),
+        std::optional<infini::rt::TensorView>{},
         std::optional<float>{planned->alpha},
         std::optional<float>{planned->beta},
         std::optional<int>{},


### PR DESCRIPTION
## What

- Pass an empty `std::optional<infini::rt::TensorView>` for the new Gemm input-C parameter.
- Advance the InfiniOps submodule from `8348acc69fd0c792f7243bbc7404dd8db4205798` to the focused prerequisite `1b9c37659211eeaeedb48b9691f79e4c9e4412f9` ([InfiniOps #878](https://github.com/InfiniTensor/InfiniOps/pull/878)).

## Why

InfiniOps #878 split Gemm's optional input C from output Y. InfiniCore still instantiated the old seven-argument call, so the shared library retained an unresolved old-signature symbol and Python import failed at `dlopen` when used with current InfiniOps.

## Scope

This restores the `C=None` / effective `beta=0` path used by current inference and Matmul. It does not add non-null C or general `beta != 0` support; that implementation is still tracked by the draft [InfiniOps #870](https://github.com/InfiniTensor/InfiniOps/pull/870).

Screenshots: N/A (backend API compatibility only).

## Validation

All build and runtime validation ran on `ssh nvidia` in `accelerator-dev/nvidia:latest` (`sha256:dd94fce2f83a180e2271f02f69713de5360aaf916b01e1f7f54173519fd54efd`) on NVIDIA A100 GPUs.

- PR dependency pin (`InfiniOps@1b9c3765`): InfiniOps and InfiniCore build/install, editable Python install, `import infinicore`, and Qwen3-0.6B CUDA inference passed (`42,515.44 ms`).
- Focused Matmul regression: 42/42 cases passed across seven shape/stride groups, FP16/BF16/FP32, and out-of-place/in-place output paths.
- Current InfiniOps `master` (`e733e325`): rebuild/install/import and Qwen3-0.6B CUDA inference passed (`42,494.8 ms`). The first inference attempt selected GPU 0 while an unrelated VLLM process held 75,558 MiB and failed allocation; the identical inference rerun on free GPU 1 passed.
- `python scripts/format.py --ref origin/main --path src/infinicore/ops/gemm/gemm_infiniops.cc --check`
- `git diff --check`

Fixes #1465
