### PR TITLE
refactor(ops): migrate paged caching to canonical InfiniOps API

### DIFF
--- a/src/infinicore/ops/paged_caching/paged_caching_infiniops.cc
+++ b/src/infinicore/ops/paged_caching/paged_caching_infiniops.cc
@@ -1,23 +1,33 @@
 #include "infinicore/ops/paged_caching.hpp"
 
+#include <string>
+
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/paged_caching_infinilm.h"
+#include "base/reshape_and_cache_flash.h"
 
 namespace infinicore::op::paged_caching_impl::infiniops {
 namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 struct PlannedMeta {
-    TensorMeta k_cache, v_cache, k, v, slot_mapping;
-    graph::GraphTensor k_cache_tensor, v_cache_tensor, k_tensor, v_tensor, slot_mapping_tensor;
+    TensorMeta k, v, slot_mapping, scale, k_cache, v_cache;
+    graph::GraphTensor k_tensor, v_tensor, slot_mapping_tensor, scale_tensor, k_cache_tensor, v_cache_tensor;
 };
 } // namespace
 
 void *plan(Tensor k_cache, Tensor v_cache, const Tensor &k, const Tensor &v, const Tensor &slot_mapping) {
     INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(k_cache->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(k_cache, v_cache, k, v, slot_mapping);
-    return new PlannedMeta{TensorMeta(k_cache), TensorMeta(v_cache), TensorMeta(k), TensorMeta(v), TensorMeta(slot_mapping), graph::GraphTensor(k_cache), graph::GraphTensor(v_cache), graph::GraphTensor(k), graph::GraphTensor(v), graph::GraphTensor(slot_mapping)};
+
+    // The "auto" cache path ignores scales, but the canonical API requires them.
+    auto scale = Tensor::empty({1}, DataType::F32, k_cache->device());
+    auto k_cache_view = k_cache->permute({0, 2, 1, 3});
+    auto v_cache_view = v_cache->permute({0, 2, 1, 3});
+
+    return new PlannedMeta{
+        TensorMeta(k), TensorMeta(v), TensorMeta(slot_mapping), TensorMeta(scale), TensorMeta(k_cache_view), TensorMeta(v_cache_view),
+        graph::GraphTensor(k), graph::GraphTensor(v), graph::GraphTensor(slot_mapping), graph::GraphTensor(scale), graph::GraphTensor(k_cache), graph::GraphTensor(v_cache)};
 }
 
 void run(void *planned_meta) {
@@ -25,12 +35,15 @@ void run(void *planned_meta) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    infini::ops::PagedCachingInfinilm::Call(
+    infini::ops::ReshapeAndCacheFlash::Call(
         handle,
         config,
         planned->k.tensor(planned->k_tensor),
         planned->v.tensor(planned->v_tensor),
         planned->slot_mapping.tensor(planned->slot_mapping_tensor),
+        planned->scale.tensor(planned->scale_tensor),
+        planned->scale.tensor(planned->scale_tensor),
+        std::string{"auto"},
         planned->k_cache.tensor(planned->k_cache_tensor),
         planned->v_cache.tensor(planned->v_cache_tensor));
 }


### PR DESCRIPTION
## Summary

- Replace the deprecated `PagedCachingInfinilm` dependency in the InfiniOps-backed paged-caching adapter with the canonical `ReshapeAndCacheFlash` API added by InfiniOps #883.
- Preserve the existing InfiniCore `paged_caching(k_cache, v_cache, key, value, slot_mapping)` public API.
- Present the existing HND cache tensors to InfiniOps as metadata-only NHD views; cache storage is not copied.
- Use `kv_cache_dtype = auto` and one persistent scalar scale tensor, which the current `auto` path ignores.

## API Migration

| Layer | Before | After | Alignment |
| --- | --- | --- | --- |
| InfiniCore public API | `paged_caching(k_cache, v_cache, key, value, slot_mapping)` | Unchanged | Existing InfiniCore contract |
| InfiniOps adapter | `PagedCachingInfinilm::Call(key, value, slot_mapping, key_cache, value_cache)` | `ReshapeAndCacheFlash::Call(key, value, slot_mapping, k_scale, v_scale, kv_cache_dtype, key_cache, value_cache)` | [vLLM `reshape_and_cache_flash`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/_custom_ops.py#L2521-L2540), adapted to InfiniOps input/attribute/output grouping |

Dependency: [InfiniOps #883](https://github.com/InfiniTensor/InfiniOps/pull/883), merged as `e733e325`.

## Validation

Remote environment: `ssh nvidia`, image `accelerator-dev/nvidia:latest`.

- `clang-format --dry-run --Werror src/infinicore/ops/paged_caching/paged_caching_infiniops.cc`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Full `infinicore_cpp_api` and `_infinicore` build/link/install: passed.
- Installed-library `ldd`: `libinfinicore_cpp_api.so` resolves `libinfiniops.so` from `python/infinicore/lib`.
- Existing `test/infinicore/ops/paged_caching.py --nvidia`, restricted to its eight equal-head-size configurations: 24/24 passed across FP16, BF16, FP32, HND, and NHD physical cache layouts.

The full integration build used an InfiniOps validation tree containing open PRs #887-#891 because current InfiniCore adapters also reference the providers covered by those PRs. This change itself pins only merged InfiniOps #883.

## Known Limitation

The final DeepSeek MLA case in the existing test uses key/value head sizes 576/512. It runs after all 24 standard cases and is rejected by the canonical API's equal-shape constraint. This is not introduced by the migration: deprecated `PagedCachingInfinilm` also asserts equal key/value and cache shapes. Extending that behavior belongs in a separate operator/API change.