### PR TITLE
refactor(ops): migrate activation adapters to canonical InfiniOps APIs

### DIFF
--- a/src/infinicore/ops/relu/relu_infiniops.cc
+++ b/src/infinicore/ops/relu/relu_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/relu_infinilm.h"
+#include "base/relu.h"
 
 namespace infinicore::op::relu_impl::infiniops {
 namespace {
@@ -20,7 +20,7 @@ void calculate(Tensor output, Tensor input) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::ReluInfinilm::Call(
+    infini::ops::Relu::Call(
         handle,
         config,
         input_meta.tensor(input),

--- a/src/infinicore/ops/silu_and_mul/silu_and_mul_infiniops.cc
+++ b/src/infinicore/ops/silu_and_mul/silu_and_mul_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/silu_and_mul_infinilm.h"
+#include "base/silu_and_mul.h"
 
 namespace infinicore::op::silu_and_mul_impl::infiniops {
 namespace {
@@ -25,7 +25,7 @@ void run(void *planned_meta) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    infini::ops::SiluAndMulInfinilm::Call(
+    infini::ops::SiluAndMul::Call(
         handle, config, planned->input.tensor(planned->input_tensor), planned->output.tensor(planned->output_tensor));
 }
 


### PR DESCRIPTION
## Summary

- migrate the InfiniCore ReLU adapter from deprecated `ReluInfinilm` to canonical `Relu`
- migrate the InfiniCore SiLU-and-multiply adapter from deprecated `SiluAndMulInfinilm` to canonical `SiluAndMul`
- keep the InfiniCore public API, dispatch behavior, and pinned InfiniOps submodule unchanged

## API alignment

| InfiniCore adapter | Previous InfiniOps API | Canonical InfiniOps API | Alignment target and evidence |
| --- | --- | --- | --- |
| ReLU | `ReluInfinilm::Call(handle, config, input, out)` | `Relu::Call(handle, config, input, out)` | PyTorch Python API: [`torch.nn.functional.relu(input, inplace=False)`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.relu.html). InfiniOps retains its C++ input/output convention while using the canonical operator name and unary input contract. |
| SiLU and multiply | `SiluAndMulInfinilm::Call(handle, config, input, out)` | `SiluAndMul::Call(handle, config, input, out)` | vLLM Python API: [`SiluAndMul.forward(x) -> Tensor`](https://github.com/vllm-project/vllm/blob/88402a41c4ab272ebbbd33f4a77fbbac0431cbb9/vllm/model_executor/layers/activation.py#L118-L160), with `x[..., :d]` gated by SiLU and multiplied by `x[..., d:]`. InfiniOps exposes the same single-input contract with an explicit output tensor. |

The currently pinned InfiniOps commit (`1b9c37659211eeaeedb48b9691f79e4c9e4412f9`) already provides both canonical operators, so this PR does not update the submodule.

## Validation

Validated commit `0dbf6e0d` remotely on `ssh nvidia` with `accelerator-dev/nvidia:latest`:

- built and installed `_infinicore` from a clean checkout with the exact pinned submodules
- confirmed `libinfinicore_cpp_api.so` resolves `libinfiniops.so` from the exact installed package
- ran `python3 test/infinicore/ops/silu_and_mul.py --nvidia`: 36/36 passed across FP16, BF16, FP32, functional, and out-parameter cases
- compiled and ran a temporary C++ smoke test through `infinicore::op::relu` on NVIDIA; device execution and host result comparison passed
- `clang-format-16 --dry-run --Werror` passed for both changed files
- `git diff --check` passed