### PR TITLE
refactor(ops): migrate rearrange to canonical InfiniOps API

### DIFF
--- a/src/infinicore/ops/rearrange/rearrange_infiniops.cc
+++ b/src/infinicore/ops/rearrange/rearrange_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/rearrange_infinilm.h"
+#include "base/copy.h"
 
 namespace infinicore::op::rearrange_impl::infiniops {
 namespace {
@@ -25,8 +25,8 @@ void run(void *planned_meta) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    infini::ops::RearrangeInfinilm::Call(
-        handle, config, planned->x.tensor(planned->x_tensor), planned->y.tensor(planned->y_tensor));
+    infini::ops::Copy::Call(
+        handle, config, planned->x.tensor(planned->x_tensor), false, planned->y.tensor(planned->y_tensor));
 }
 
 void cleanup(void **planned_meta_ptr) {


### PR DESCRIPTION
## Summary

- migrate the InfiniCore rearrange adapter from deprecated `RearrangeInfinilm` to canonical `Copy`
- pass `non_blocking=false`, matching the legacy synchronous same-device behavior
- keep the InfiniCore public API, graph planning, and active dispatcher selection unchanged

## API alignment

| InfiniCore adapter | Previous InfiniOps API | Canonical InfiniOps API | Alignment target and evidence |
| --- | --- | --- | --- |
| Rearrange | `RearrangeInfinilm::Call(handle, config, src, out)` | `Copy::Call(handle, config, src, false, out)` | PyTorch [`Tensor.copy_(src, non_blocking=False)`](https://docs.pytorch.org/docs/2.13/generated/torch.Tensor.copy_.html). InfiniOps preserves `src, non_blocking` and represents the mutable receiver as the trailing explicit `out` tensor per its input-attribute-output convention. |

## Dependency

This PR is based on `refactor/migrate-paged-caching-infiniops` / #1467 because that branch advances the InfiniOps gitlink to `e733e325b4af776261419e4dc7e1f9386c05fa71`, which includes the canonical `Copy` operator from [InfiniOps #872](https://github.com/InfiniTensor/InfiniOps/pull/872).

Against #1467, this PR changes one file with three insertions and three deletions. After #1467 merges, this PR can be retargeted to `main` without carrying an additional submodule update.

## Validation

Validated commit `e89ff869` remotely on `ssh nvidia` with `accelerator-dev/nvidia:latest`, using the exact InfiniOps gitlink `e733e325`:

- built and installed `_infinicore` with the canonical `copy` provider in the wrapper allowlist
- compiled and ran a temporary C++ smoke test that directly invoked `rearrange_impl::infiniops::plan`, `run`, and `cleanup` on an NVIDIA tensor; copied values and plan cleanup were verified
- `clang-format 16.0.6 --dry-run --Werror` passed for the changed file
- `git diff --check` passed