### PR TITLE
refactor(ops): migrate conv2d to canonical InfiniOps API

### DIFF
--- a/src/infinicore/ops/conv2d/conv2d_infiniops.cc
+++ b/src/infinicore/ops/conv2d/conv2d_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/conv_infinilm.h"
+#include "base/conv2d.h"
 
 #include <optional>
 #include <vector>
@@ -48,14 +48,14 @@ void calculate(Tensor output,
         bias_meta.emplace(bias);
     }
 
-    infini::ops::ConvInfinilm::Call(
+    infini::ops::Conv2d::Call(
         handle,
         config,
         input_meta.tensor(input),
         weight_meta.tensor(weight),
         bias_meta ? std::optional<infini::ops::Tensor>{bias_meta->tensor(bias)} : std::nullopt,
-        toInt64Vector(pads, n),
         toInt64Vector(strides, n),
+        toInt64Vector(pads, n),
         toInt64Vector(dilations, n),
         int64_t{1},
         output_meta.tensor(output));


### PR DESCRIPTION
## Summary

- migrate the InfiniCore Conv2d adapter from deprecated `ConvInfinilm` to canonical `Conv2d`
- map the existing convolution arguments to the canonical `stride`, `padding`, and `dilation` order
- keep the InfiniCore public API, graph planning, and execution behavior unchanged

## API alignment

| InfiniCore adapter | Previous InfiniOps API | Canonical InfiniOps API | Alignment target and evidence |
| --- | --- | --- | --- |
| Conv2d | `ConvInfinilm::Call(handle, config, input, weight, bias, pads, strides, dilations, groups, out)` | `Conv2d::Call(handle, config, input, weight, bias, stride, padding, dilation, groups, out)` | PyTorch Python API: [`torch.nn.functional.conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1)`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.conv2d.html). InfiniOps preserves the Python argument order and adds the explicit trailing output required by its C++ input-attribute-output convention. |

## Dependency

This PR is based on `refactor/migrate-paged-caching-infiniops` / #1467 and advances the InfiniOps gitlink from `e733e325` to `1ecce783`, the head of [InfiniOps #887](https://github.com/InfiniTensor/InfiniOps/pull/887). The canonical convolution schemas landed in [InfiniOps #882](https://github.com/InfiniTensor/InfiniOps/pull/882); #887 supplies the focused metadata-view compatibility fix needed to build them against the current InfiniRT API.

Against #1467, this PR changes one adapter file and the InfiniOps gitlink.

## Validation

Validated commit `a35c077b` remotely on `ssh nvidia` with `accelerator-dev/nvidia:latest`, using the exact InfiniOps #887 head `1ecce783` in a temporary integration merge:

- built and installed `_infinicore` with the canonical `conv2d` provider in the wrapper allowlist
- ran `python3 test/infinicore/ops/conv2d.py --nvidia`: 12/12 passed
- `clang-format 16.0.6 --dry-run --Werror` passed for the changed C++ file
- `git diff --check` passed
