### PR TITLE
refactor(ops): migrate softmax to canonical InfiniOps API

### DIFF
--- a/src/infinicore/ops/softmax/softmax_infiniops.cc
+++ b/src/infinicore/ops/softmax/softmax_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/softmax_infinilm.h"
+#include "base/softmax.h"
 
 #include <optional>
 
@@ -22,7 +22,7 @@ void calculate(Tensor output, Tensor input, int axis) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::SoftmaxInfinilm::Call(
+    infini::ops::Softmax::Call(
         handle,
         config,
         input_meta.tensor(input),


### PR DESCRIPTION
## Summary

- migrate the InfiniCore softmax adapter from deprecated `SoftmaxInfinilm` to canonical `Softmax`
- preserve the existing input, dimension, optional dtype, and output mapping
- keep the InfiniCore public API, graph planning, and execution behavior unchanged

## API alignment

| InfiniCore adapter | Previous InfiniOps API | Canonical InfiniOps API | Alignment target and evidence |
| --- | --- | --- | --- |
| Softmax | `SoftmaxInfinilm::Call(handle, config, input, dim, dtype, out)` | `Softmax::Call(handle, config, input, dim, dtype, out)` | PyTorch Python API: [`torch.nn.functional.softmax(input, dim=None, _stacklevel=3, dtype=None)`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.softmax.html). InfiniOps omits Python's internal `_stacklevel` argument and adds the explicit trailing C++ output tensor. |

## Dependency

This PR is based on `refactor/migrate-paged-caching-infiniops` / #1467 and advances the InfiniOps gitlink from `e733e325` to `eec65a13`, the head of [InfiniOps #890](https://github.com/InfiniTensor/InfiniOps/pull/890), which adds canonical CUDA-compatible softmax providers.

Against #1467, this PR changes one adapter file and the InfiniOps gitlink.

## Validation

Validated commit `86bec726` remotely on `ssh nvidia` with `accelerator-dev/nvidia:latest`, using the exact InfiniOps #890 head `eec65a13` in a temporary integration merge:

- built and installed `_infinicore` with the canonical `softmax` provider in the wrapper allowlist
- compiled and ran a temporary C++ NVIDIA smoke test through `infinicore::op::softmax`; output matched a row-wise host reference
- `clang-format 16.0.6 --dry-run --Werror` passed for the changed C++ file
- `git diff --check` passed
