### PR TITLE
refactor(ops): migrate topksoftmax to canonical InfiniOps API

### DIFF
--- a/src/infinicore/ops/topksoftmax/topksoftmax_infiniops.cc
+++ b/src/infinicore/ops/topksoftmax/topksoftmax_infiniops.cc
@@ -3,15 +3,16 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/topksoftmax_infinilm.h"
+#include "base/topk_softmax.h"
+
+#include <optional>
 
 namespace infinicore::op::topksoftmax_impl::infiniops {
 namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 struct PlannedMeta {
-    TensorMeta values, indices, x;
-    graph::GraphTensor values_tensor, indices_tensor, x_tensor;
-    size_t topk;
+    TensorMeta values, indices, token_expert_indices, x;
+    graph::GraphTensor values_tensor, indices_tensor, token_expert_indices_tensor, x_tensor;
     int norm;
 };
 } // namespace
@@ -19,7 +20,17 @@ struct PlannedMeta {
 void *plan(Tensor values, Tensor indices, const Tensor &x, const size_t topk, const int norm) {
     INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(values->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(values, indices, x);
-    return new PlannedMeta{TensorMeta(values), TensorMeta(indices), TensorMeta(x), graph::GraphTensor(values), graph::GraphTensor(indices), graph::GraphTensor(x), topk, norm};
+    auto token_expert_indices = Tensor::empty({x->size(0), topk}, DataType::I32, indices->device());
+    return new PlannedMeta{
+        TensorMeta(values),
+        TensorMeta(indices),
+        TensorMeta(token_expert_indices),
+        TensorMeta(x),
+        graph::GraphTensor(values),
+        graph::GraphTensor(indices),
+        graph::GraphTensor(token_expert_indices),
+        graph::GraphTensor(x),
+        norm};
 }
 
 void run(void *planned_meta) {
@@ -27,14 +38,16 @@ void run(void *planned_meta) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    infini::ops::TopksoftmaxInfinilm::Call(
+    infini::ops::TopkSoftmax::Call(
         handle,
         config,
         planned->x.tensor(planned->x_tensor),
-        static_cast<int64_t>(planned->topk),
+        std::optional<infini::ops::Tensor>{},
+        std::optional<infini::ops::Tensor>{},
         planned->norm != 0,
         planned->values.tensor(planned->values_tensor),
-        planned->indices.tensor(planned->indices_tensor));
+        planned->indices.tensor(planned->indices_tensor),
+        planned->token_expert_indices.tensor(planned->token_expert_indices_tensor));
 }
 
 void cleanup(void **planned_meta_ptr) {


### PR DESCRIPTION
## Summary

- migrate the InfiniCore topksoftmax adapter from deprecated `TopkSoftmaxInfinilm` to canonical `TopkSoftmax`
- provide the canonical auxiliary `token_expert_indices` output as plan-owned internal storage
- keep the InfiniCore public two-output API and existing `norm` behavior unchanged

## API alignment

| InfiniCore adapter | Previous InfiniOps API | Canonical InfiniOps API | Alignment target and evidence |
| --- | --- | --- | --- |
| Top-k softmax | `TopkSoftmaxInfinilm::Call(handle, config, gating_output, topk, renormalize, topk_weights, topk_indices)` | `TopkSoftmax::Call(handle, config, gating_output, bias, is_padding, renormalize, topk_weights, topk_indices, token_expert_indices)` | vLLM Python API: [`topk_softmax(topk_weights, topk_ids, token_expert_indices, gating_output, renormalize=False, e_score_correction_bias=None, is_padding=None)`](https://github.com/vllm-project/vllm/blob/88402a41c4ab272ebbbd33f4a77fbbac0431cbb9/vllm/_custom_ops.py#L2385-L2413). InfiniOps groups inputs, attributes, and explicit outputs; `bias` maps to `e_score_correction_bias`, and `topk_indices` maps to `topk_ids`. |

The existing InfiniCore public API does not expose bias, padding, or the auxiliary token-to-expert output. This adapter passes null optional inputs and allocates the required third output in plan-owned storage. Its shape retains the caller's existing `topk` selection, while the canonical operator derives `topk` from the output shape.

## Dependency

This PR is based on `refactor/migrate-paged-caching-infiniops` / #1467 and advances the InfiniOps gitlink from `e733e325` to `1a712d0c`, the head of [InfiniOps #891](https://github.com/InfiniTensor/InfiniOps/pull/891), which extends the canonical provider to the CUDA-compatible backends used by InfiniCore.

Against #1467, this PR changes one adapter file and the InfiniOps gitlink.

## Validation

Validated commit `3199b309` remotely on `ssh nvidia` with `accelerator-dev/nvidia:latest`, using the exact InfiniOps #891 head `1a712d0c` in a temporary integration merge:

- built and installed `_infinicore` with the canonical `topk_softmax` provider in the wrapper allowlist
- ran `python3 test/infinicore/ops/topksoftmax.py --nvidia`: 24/24 passed
- `clang-format 16.0.6 --dry-run --Werror` passed for the changed C++ file
- `git diff --check` passed
