### PR TITLE
refactor(ops): migrate GELU and sigmoid to canonical InfiniOps APIs

### DIFF
--- a/src/infinicore/ops/gelu/gelu_infiniops.cc
+++ b/src/infinicore/ops/gelu/gelu_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/gelu_infinilm.h"
+#include "base/gelu.h"
 
 #include <string>
 
@@ -22,7 +22,7 @@ void calculate(Tensor output, Tensor input) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::GeluInfinilm::Call(
+    infini::ops::Gelu::Call(
         handle,
         config,
         input_meta.tensor(input),

--- a/src/infinicore/ops/gelutanh/gelutanh_infiniops.cc
+++ b/src/infinicore/ops/gelutanh/gelutanh_infiniops.cc
@@ -3,7 +3,9 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/gelutanh_infinilm.h"
+#include "base/gelu.h"
+
+#include <string>
 
 namespace infinicore::op::gelutanh_impl::infiniops {
 namespace {
@@ -20,10 +22,11 @@ void calculate(Tensor output, Tensor input) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::GelutanhInfinilm::Call(
+    infini::ops::Gelu::Call(
         handle,
         config,
         input_meta.tensor(input),
+        std::string{"tanh"},
         output_meta.tensor(output));
 }
 

--- a/src/infinicore/ops/sigmoid/sigmoid_infiniops.cc
+++ b/src/infinicore/ops/sigmoid/sigmoid_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/sigmoid_infinilm.h"
+#include "base/sigmoid.h"
 
 namespace infinicore::op::sigmoid_impl::infiniops {
 namespace {
@@ -35,7 +35,7 @@ void run(void *planned_meta) {
     handle.set_stream(context::getStream());
     infini::ops::Config config;
 
-    infini::ops::SigmoidInfinilm::Call(
+    infini::ops::Sigmoid::Call(
         handle,
         config,
         planned->input.tensor(planned->input_tensor),


### PR DESCRIPTION
## Summary

- migrate the InfiniCore GELU adapters from deprecated `GeluInfinilm` and `GelutanhInfinilm` to canonical `Gelu`
- select the PyTorch-compatible `none` and `tanh` approximation modes explicitly
- migrate the sigmoid adapter from deprecated `SigmoidInfinilm` to canonical `Sigmoid`
- keep the InfiniCore public APIs and graph behavior unchanged

## API alignment

| InfiniCore adapter | Previous InfiniOps API | Canonical InfiniOps API | Alignment target and evidence |
| --- | --- | --- | --- |
| GELU | `GeluInfinilm::Call(handle, config, input, approximate, out)` | `Gelu::Call(handle, config, input, approximate, out)` | PyTorch Python API: [`torch.nn.functional.gelu(input, approximate='none')`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.gelu.html). The ordinary adapter passes `none`; the tanh adapter passes `tanh`. InfiniOps adds an explicit trailing output tensor. |
| Sigmoid | `SigmoidInfinilm::Call(handle, config, input, out)` | `Sigmoid::Call(handle, config, input, out)` | PyTorch Python API: [`torch.sigmoid(input, *, out=None)`](https://docs.pytorch.org/docs/stable/generated/torch.sigmoid.html). InfiniOps represents the optional Python output as its required trailing C++ output tensor. |

## Dependency

This PR is based on `refactor/migrate-paged-caching-infiniops` / #1467 and advances the InfiniOps gitlink from `e733e325` to `498c9aaa`, the head of [InfiniOps #889](https://github.com/InfiniTensor/InfiniOps/pull/889), which adds canonical CUDA-compatible GELU and sigmoid providers.

Against #1467, this PR changes three adapter files and the InfiniOps gitlink.

## Validation

Validated commit `37b8fb8b` remotely on `ssh nvidia` with `accelerator-dev/nvidia:latest`, using the exact InfiniOps #889 head `498c9aaa` in a temporary integration merge:

- built and installed `_infinicore` with the canonical `gelu` and `sigmoid` providers in the wrapper allowlist
- ran `python3 test/infinicore/ops/sigmoid.py --nvidia`: 45/45 passed
- compiled and ran a temporary C++ NVIDIA smoke test through `infinicore::op::gelu` and `infinicore::op::gelu_tanh`; both outputs matched host references
- `clang-format 16.0.6 --dry-run --Werror` passed for all three changed C++ files
- `git diff --check` passed
