### PR TITLE
refactor(ops): use canonical InfiniOps activation APIs

### DIFF
--- a/src/infinicore/ops/gelu/gelu_infiniops.cc
+++ b/src/infinicore/ops/gelu/gelu_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/gelu_infinilm.h"
+#include "base/gelu.h"
 
 #include <string>
 
@@ -22,7 +22,7 @@ void calculate(Tensor output, Tensor input) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::GeluInfinilm::Call(
+    infini::ops::Gelu::Call(
         handle,
         config,
         input_meta.tensor(input),

--- a/src/infinicore/ops/gelutanh/gelutanh_infiniops.cc
+++ b/src/infinicore/ops/gelutanh/gelutanh_infiniops.cc
@@ -3,7 +3,9 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/gelutanh_infinilm.h"
+#include "base/gelu.h"
+
+#include <string>
 
 namespace infinicore::op::gelutanh_impl::infiniops {
 namespace {
@@ -20,10 +22,11 @@ void calculate(Tensor output, Tensor input) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::GelutanhInfinilm::Call(
+    infini::ops::Gelu::Call(
         handle,
         config,
         input_meta.tensor(input),
+        std::string{"tanh"},
         output_meta.tensor(output));
 }
 

--- a/src/infinicore/ops/relu/relu_infiniops.cc
+++ b/src/infinicore/ops/relu/relu_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/relu_infinilm.h"
+#include "base/relu.h"
 
 namespace infinicore::op::relu_impl::infiniops {
 namespace {
@@ -20,7 +20,7 @@ void calculate(Tensor output, Tensor input) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::ReluInfinilm::Call(
+    infini::ops::Relu::Call(
         handle,
         config,
         input_meta.tensor(input),

--- a/src/infinicore/ops/sigmoid/sigmoid_infiniops.cc
+++ b/src/infinicore/ops/sigmoid/sigmoid_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/sigmoid_infinilm.h"
+#include "base/sigmoid.h"
 
 namespace infinicore::op::sigmoid_impl::infiniops {
 namespace {
@@ -35,7 +35,7 @@ void run(void *planned_meta) {
     handle.set_stream(context::getStream());
     infini::ops::Config config;
 
-    infini::ops::SigmoidInfinilm::Call(
+    infini::ops::Sigmoid::Call(
         handle,
         config,
         planned->input.tensor(planned->input_tensor),

--- a/src/infinicore/ops/silu_and_mul/silu_and_mul_infiniops.cc
+++ b/src/infinicore/ops/silu_and_mul/silu_and_mul_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/silu_and_mul_infinilm.h"
+#include "base/silu_and_mul.h"
 
 namespace infinicore::op::silu_and_mul_impl::infiniops {
 namespace {
@@ -25,7 +25,7 @@ void run(void *planned_meta) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    infini::ops::SiluAndMulInfinilm::Call(
+    infini::ops::SiluAndMul::Call(
         handle, config, planned->input.tensor(planned->input_tensor), planned->output.tensor(planned->output_tensor));
 }
 


### PR DESCRIPTION
## What

- Advance InfiniOps from `1b9c3765` to `21b07ebc`.
- Replace the InfiniLM-suffixed GELU, GELU-tanh, ReLU, sigmoid, and SiLU-and-mul adapter calls with their canonical InfiniOps APIs.
- Preserve every InfiniCore public signature and execution path.

## Alignment

| InfiniCore wrapper | InfiniOps call | Alignment basis |
| --- | --- | --- |
| `gelu` | `Gelu(input, none, out)` | [`torch.nn.functional.gelu(input, approximate=none)`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.gelu.html), [InfiniOps `Gelu`](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/gelu.h) |
| `gelutanh` | `Gelu(input, tanh, out)` | [`torch.nn.functional.gelu(..., approximate=tanh)`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.gelu.html), [InfiniOps #889](https://github.com/InfiniTensor/InfiniOps/pull/889) |
| `relu` | `Relu(input, out)` | [`torch.nn.functional.relu(input, inplace=False)`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.relu.html), [InfiniOps `Relu`](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/relu.h) |
| `sigmoid` | `Sigmoid(input, out)` | [`torch.sigmoid(input)`](https://docs.pytorch.org/docs/stable/generated/torch.sigmoid.html), [InfiniOps `Sigmoid`](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/sigmoid.h) |
| `silu_and_mul` | `SiluAndMul(input, out)` | [vLLM `SiluAndMul`](https://docs.vllm.ai/en/stable/api/vllm/model_executor/layers/activation/#vllm.model_executor.layers.activation.SiluAndMul), [InfiniOps `SiluAndMul`](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/silu_and_mul.h) |

InfiniOps follows its C++ convention of input tensors, attributes, then output tensors; this PR only changes the adapter target.

## Why

The canonical providers are now available in InfiniOps, so these adapters no longer need the deprecated `*Infinilm` compatibility classes.

## Scope

No Python/C++ public InfiniCore API, tensor layout, or kernel behavior changes. The InfiniOps pin also contains the canonical APIs used by the following stacked migration PRs.

Screenshots: N/A (backend adapter migration only).

## Validation

Run on `ssh nvidia` in `accelerator-dev/nvidia:latest` on NVIDIA A100 GPUs:

- Full `infinicore_cpp_api` and `_infinicore` build/install passed.
- Python extension import and dynamic linking passed with InfiniOps' private InfiniRT SONAME path.
- Existing sigmoid NVIDIA suite: 45/45 passed.
- Existing SiLU-and-mul NVIDIA suite: 36/36 passed.
- `python3 scripts/format.py --ref 850fb3f7 --path src --check` with clang-format 16.0.6.
- `git diff --check`.