### PR TITLE
refactor(ops): use canonical InfiniOps softmax API

### DIFF
--- a/src/infinicore/ops/softmax/softmax_infiniops.cc
+++ b/src/infinicore/ops/softmax/softmax_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/softmax_infinilm.h"
+#include "base/softmax.h"
 
 #include <optional>
 
@@ -22,7 +22,7 @@ void calculate(Tensor output, Tensor input, int axis) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::SoftmaxInfinilm::Call(
+    infini::ops::Softmax::Call(
         handle,
         config,
         input_meta.tensor(input),


### PR DESCRIPTION
## What

- Replace `SoftmaxInfinilm` with the canonical InfiniOps `Softmax` API.
- Preserve the existing InfiniCore axis and output handling.

## Alignment

| InfiniCore wrapper | InfiniOps call | Alignment basis |
| --- | --- | --- |
| `softmax(input, dim, out)` | `Softmax(input, dim, dtype=nullopt, out)` | [`torch.nn.functional.softmax(input, dim, dtype=None)`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.softmax.html), [InfiniOps `Softmax`](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/softmax.h), [InfiniOps #890](https://github.com/InfiniTensor/InfiniOps/pull/890) |

The omitted dtype remains `std::nullopt`, matching the existing behavior of preserving the input dtype.

## Why

InfiniOps now exposes the standard PyTorch-aligned softmax interface and its CUDA provider, so the deprecated InfiniLM compatibility class is no longer needed by this adapter.

## Scope

This is stacked on #1476 for the validated InfiniOps pin. It does not change the public InfiniCore softmax API or add overloads.

Screenshots: N/A (backend adapter migration only).

## Validation

Run on `ssh nvidia` in `accelerator-dev/nvidia:latest` on NVIDIA A100 GPUs:

- Full `infinicore_cpp_api` and `_infinicore` build/install passed.
- Python extension import and dynamic linking passed.
- `python3 scripts/format.py --ref 850fb3f7 --path src --check` with clang-format 16.0.6.
- `git diff --check`.