### PR TITLE
refactor(ops): use InfiniOps Copy for rearrange

### DIFF
--- a/src/infinicore/ops/rearrange/rearrange_infiniops.cc
+++ b/src/infinicore/ops/rearrange/rearrange_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/rearrange_infinilm.h"
+#include "base/copy.h"
 
 namespace infinicore::op::rearrange_impl::infiniops {
 namespace {
@@ -25,8 +25,8 @@ void run(void *planned_meta) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    infini::ops::RearrangeInfinilm::Call(
-        handle, config, planned->x.tensor(planned->x_tensor), planned->y.tensor(planned->y_tensor));
+    infini::ops::Copy::Call(
+        handle, config, planned->x.tensor(planned->x_tensor), false, planned->y.tensor(planned->y_tensor));
 }
 
 void cleanup(void **planned_meta_ptr) {
@@ -34,8 +34,5 @@ void cleanup(void **planned_meta_ptr) {
     *planned_meta_ptr = nullptr;
 }
 
-// ReArrange is used by Tensor::copy_from during test result conversion. Keep
-// the InfiniCore/InfiniOp implementation active until this adapter gets the same
-// CUDA shim treatment as Gemm.
 } // namespace infinicore::op::rearrange_impl::infiniops
 #endif


### PR DESCRIPTION
## What

- Replace `RearrangeInfinilm` with the canonical InfiniOps `Copy` API.
- Pass `non_blocking=false`, preserving the current synchronous copy behavior.
- Remove the obsolete adapter-blocking comment.

## Alignment

| InfiniCore wrapper | InfiniOps call | Alignment basis |
| --- | --- | --- |
| `rearrange(x, y)` | `Copy(input=x, non_blocking=false, out=y)` | [`Tensor.copy_(src, non_blocking=False)`](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.copy_.html), [InfiniOps `Copy`](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/copy.h), [InfiniOps #872](https://github.com/InfiniTensor/InfiniOps/pull/872), [provider adaptation #897](https://github.com/InfiniTensor/InfiniOps/pull/897) |

InfiniOps keeps its C++ input/attribute/output ordering while retaining PyTorch's source tensor and `non_blocking` contract.

## Why

The canonical `Copy` operator and CUDA adaptation are now available, so this adapter no longer needs the deprecated InfiniLM-specific rearrange class.

## Scope

This is stacked on #1477. It changes only the InfiniOps adapter target; the public InfiniCore rearrange API and copy semantics remain unchanged.

Screenshots: N/A (backend adapter migration only).

## Validation

Run on `ssh nvidia` in `accelerator-dev/nvidia:latest` on NVIDIA A100 GPUs:

- Full `infinicore_cpp_api` and `_infinicore` build/install passed.
- Python extension import and dynamic linking passed.
- Existing NVIDIA suites completed after the copy migration: sigmoid 45/45, SiLU-and-mul 36/36, and conv2d 12/12.
- `python3 scripts/format.py --ref 850fb3f7 --path src --check` with clang-format 16.0.6.
- `git diff --check`.