### PR TITLE
refactor(ops): use InfiniOps Convolution for conv2d

### DIFF
--- a/src/infinicore/ops/conv2d/conv2d_infiniops.cc
+++ b/src/infinicore/ops/conv2d/conv2d_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/conv_infinilm.h"
+#include "base/convolution.h"
 
 #include <optional>
 #include <vector>
@@ -48,15 +48,17 @@ void calculate(Tensor output,
         bias_meta.emplace(bias);
     }
 
-    infini::ops::ConvInfinilm::Call(
+    infini::ops::Convolution::Call(
         handle,
         config,
         input_meta.tensor(input),
         weight_meta.tensor(weight),
         bias_meta ? std::optional<infini::ops::Tensor>{bias_meta->tensor(bias)} : std::nullopt,
-        toInt64Vector(pads, n),
         toInt64Vector(strides, n),
+        toInt64Vector(pads, n),
         toInt64Vector(dilations, n),
+        false,
+        std::vector<int64_t>(n, 0),
         int64_t{1},
         output_meta.tensor(output));
 }


### PR DESCRIPTION
## What

- Replace `ConvInfinilm` with the canonical InfiniOps `Convolution` API.
- Supply the existing conv2d contract explicitly: `transposed=false`, zero `output_padding`, and `groups=1`.
- Keep input, weight, optional bias, stride, padding, dilation, and output handling unchanged.

## Alignment

| InfiniCore wrapper | InfiniOps call | Alignment basis |
| --- | --- | --- |
| `conv2d` | `Convolution(input, weight, bias, stride, padding, dilation, transposed=false, output_padding=0, groups=1, out)` | [`torch.nn.functional.conv2d(input, weight, bias, stride, padding, dilation, groups)`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.conv2d.html), [ATen `convolution` schema](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/native_functions.yaml), [InfiniOps `Convolution`](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/convolution.h), [InfiniOps #882](https://github.com/InfiniTensor/InfiniOps/pull/882) |

The call follows InfiniOps' C++ input/attribute/output ordering and maps the non-transposed conv2d subset onto the full PyTorch/ATen convolution contract.

## Why

The old InfiniLM convolution provider now backs the canonical `Convolution` operator, so the deprecated `ConvInfinilm` class is no longer required by InfiniCore.

## Scope

This is stacked on #1478. It does not expand conv2d feature support or change the public InfiniCore API.

Screenshots: N/A (backend adapter migration only).

## Validation

Run on `ssh nvidia` in `accelerator-dev/nvidia:latest` on NVIDIA A100 GPUs:

- Full `infinicore_cpp_api` and `_infinicore` build/install passed.
- Python extension import and dynamic linking passed.
- Existing conv2d NVIDIA suite: 12/12 passed, covering FP16/FP32, optional bias, scalar/tuple stride, padding, dilation, and strided input.
- `python3 scripts/format.py --ref 850fb3f7 --path src --check` with clang-format 16.0.6.
- `git diff --check`.