### PR TITLE
refactor(ops): migrate InfiniLM adapters to canonical InfiniOps APIs

### DIFF
--- a/src/infinicore/ops/conv2d/conv2d_infiniops.cc
+++ b/src/infinicore/ops/conv2d/conv2d_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/conv_infinilm.h"
+#include "base/convolution.h"
 
 #include <optional>
 #include <vector>
@@ -48,15 +48,17 @@ void calculate(Tensor output,
         bias_meta.emplace(bias);
     }
 
-    infini::ops::ConvInfinilm::Call(
+    infini::ops::Convolution::Call(
         handle,
         config,
         input_meta.tensor(input),
         weight_meta.tensor(weight),
         bias_meta ? std::optional<infini::ops::Tensor>{bias_meta->tensor(bias)} : std::nullopt,
-        toInt64Vector(pads, n),
         toInt64Vector(strides, n),
+        toInt64Vector(pads, n),
         toInt64Vector(dilations, n),
+        false,
+        std::vector<int64_t>(n, 0),
         int64_t{1},
         output_meta.tensor(output));
 }

--- a/src/infinicore/ops/gelu/gelu_infiniops.cc
+++ b/src/infinicore/ops/gelu/gelu_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/gelu_infinilm.h"
+#include "base/gelu.h"
 
 #include <string>
 
@@ -22,7 +22,7 @@ void calculate(Tensor output, Tensor input) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::GeluInfinilm::Call(
+    infini::ops::Gelu::Call(
         handle,
         config,
         input_meta.tensor(input),

--- a/src/infinicore/ops/gelutanh/gelutanh_infiniops.cc
+++ b/src/infinicore/ops/gelutanh/gelutanh_infiniops.cc
@@ -3,7 +3,9 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/gelutanh_infinilm.h"
+#include "base/gelu.h"
+
+#include <string>
 
 namespace infinicore::op::gelutanh_impl::infiniops {
 namespace {
@@ -20,10 +22,11 @@ void calculate(Tensor output, Tensor input) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::GelutanhInfinilm::Call(
+    infini::ops::Gelu::Call(
         handle,
         config,
         input_meta.tensor(input),
+        std::string{"tanh"},
         output_meta.tensor(output));
 }
 

--- a/src/infinicore/ops/paged_caching/paged_caching_infiniops.cc
+++ b/src/infinicore/ops/paged_caching/paged_caching_infiniops.cc
@@ -1,23 +1,33 @@
 #include "infinicore/ops/paged_caching.hpp"
 
+#include <string>
+
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/paged_caching_infinilm.h"
+#include "base/reshape_and_cache_flash.h"
 
 namespace infinicore::op::paged_caching_impl::infiniops {
 namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 struct PlannedMeta {
-    TensorMeta k_cache, v_cache, k, v, slot_mapping;
-    graph::GraphTensor k_cache_tensor, v_cache_tensor, k_tensor, v_tensor, slot_mapping_tensor;
+    TensorMeta k, v, slot_mapping, scale, k_cache, v_cache;
+    graph::GraphTensor k_tensor, v_tensor, slot_mapping_tensor, scale_tensor, k_cache_tensor, v_cache_tensor;
 };
 } // namespace
 
 void *plan(Tensor k_cache, Tensor v_cache, const Tensor &k, const Tensor &v, const Tensor &slot_mapping) {
     INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(k_cache->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(k_cache, v_cache, k, v, slot_mapping);
-    return new PlannedMeta{TensorMeta(k_cache), TensorMeta(v_cache), TensorMeta(k), TensorMeta(v), TensorMeta(slot_mapping), graph::GraphTensor(k_cache), graph::GraphTensor(v_cache), graph::GraphTensor(k), graph::GraphTensor(v), graph::GraphTensor(slot_mapping)};
+
+    // The "auto" cache path ignores scales, but the canonical API requires them.
+    auto scale = Tensor::empty({1}, DataType::F32, k_cache->device());
+    auto k_cache_view = k_cache->permute({0, 2, 1, 3});
+    auto v_cache_view = v_cache->permute({0, 2, 1, 3});
+
+    return new PlannedMeta{
+        TensorMeta(k), TensorMeta(v), TensorMeta(slot_mapping), TensorMeta(scale), TensorMeta(k_cache_view), TensorMeta(v_cache_view),
+        graph::GraphTensor(k), graph::GraphTensor(v), graph::GraphTensor(slot_mapping), graph::GraphTensor(scale), graph::GraphTensor(k_cache), graph::GraphTensor(v_cache)};
 }
 
 void run(void *planned_meta) {
@@ -25,12 +35,15 @@ void run(void *planned_meta) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    infini::ops::PagedCachingInfinilm::Call(
+    infini::ops::ReshapeAndCacheFlash::Call(
         handle,
         config,
         planned->k.tensor(planned->k_tensor),
         planned->v.tensor(planned->v_tensor),
         planned->slot_mapping.tensor(planned->slot_mapping_tensor),
+        planned->scale.tensor(planned->scale_tensor),
+        planned->scale.tensor(planned->scale_tensor),
+        std::string{"auto"},
         planned->k_cache.tensor(planned->k_cache_tensor),
         planned->v_cache.tensor(planned->v_cache_tensor));
 }

--- a/src/infinicore/ops/rearrange/rearrange_infiniops.cc
+++ b/src/infinicore/ops/rearrange/rearrange_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/rearrange_infinilm.h"
+#include "base/copy.h"
 
 namespace infinicore::op::rearrange_impl::infiniops {
 namespace {
@@ -25,8 +25,8 @@ void run(void *planned_meta) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    infini::ops::RearrangeInfinilm::Call(
-        handle, config, planned->x.tensor(planned->x_tensor), planned->y.tensor(planned->y_tensor));
+    infini::ops::Copy::Call(
+        handle, config, planned->x.tensor(planned->x_tensor), false, planned->y.tensor(planned->y_tensor));
 }
 
 void cleanup(void **planned_meta_ptr) {
@@ -34,8 +34,5 @@ void cleanup(void **planned_meta_ptr) {
     *planned_meta_ptr = nullptr;
 }
 
-// ReArrange is used by Tensor::copy_from during test result conversion. Keep
-// the InfiniCore/InfiniOp implementation active until this adapter gets the same
-// CUDA shim treatment as Gemm.
 } // namespace infinicore::op::rearrange_impl::infiniops
 #endif

--- a/src/infinicore/ops/relu/relu_infiniops.cc
+++ b/src/infinicore/ops/relu/relu_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/relu_infinilm.h"
+#include "base/relu.h"
 
 namespace infinicore::op::relu_impl::infiniops {
 namespace {
@@ -20,7 +20,7 @@ void calculate(Tensor output, Tensor input) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::ReluInfinilm::Call(
+    infini::ops::Relu::Call(
         handle,
         config,
         input_meta.tensor(input),

--- a/src/infinicore/ops/sigmoid/sigmoid_infiniops.cc
+++ b/src/infinicore/ops/sigmoid/sigmoid_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/sigmoid_infinilm.h"
+#include "base/sigmoid.h"
 
 namespace infinicore::op::sigmoid_impl::infiniops {
 namespace {
@@ -35,7 +35,7 @@ void run(void *planned_meta) {
     handle.set_stream(context::getStream());
     infini::ops::Config config;
 
-    infini::ops::SigmoidInfinilm::Call(
+    infini::ops::Sigmoid::Call(
         handle,
         config,
         planned->input.tensor(planned->input_tensor),

--- a/src/infinicore/ops/silu_and_mul/silu_and_mul_infiniops.cc
+++ b/src/infinicore/ops/silu_and_mul/silu_and_mul_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/silu_and_mul_infinilm.h"
+#include "base/silu_and_mul.h"
 
 namespace infinicore::op::silu_and_mul_impl::infiniops {
 namespace {
@@ -25,7 +25,7 @@ void run(void *planned_meta) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    infini::ops::SiluAndMulInfinilm::Call(
+    infini::ops::SiluAndMul::Call(
         handle, config, planned->input.tensor(planned->input_tensor), planned->output.tensor(planned->output_tensor));
 }
 

--- a/src/infinicore/ops/softmax/softmax_infiniops.cc
+++ b/src/infinicore/ops/softmax/softmax_infiniops.cc
@@ -3,7 +3,7 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/softmax_infinilm.h"
+#include "base/softmax.h"
 
 #include <optional>
 
@@ -22,7 +22,7 @@ void calculate(Tensor output, Tensor input, int axis) {
 
     TensorMeta output_meta(output);
     TensorMeta input_meta(input);
-    infini::ops::SoftmaxInfinilm::Call(
+    infini::ops::Softmax::Call(
         handle,
         config,
         input_meta.tensor(input),

--- a/src/infinicore/ops/topksoftmax/topksoftmax_infiniops.cc
+++ b/src/infinicore/ops/topksoftmax/topksoftmax_infiniops.cc
@@ -3,15 +3,16 @@
 #ifdef ENABLE_INFINIOPS_API
 #include "../infiniops_impl.hpp"
 
-#include "base/topksoftmax_infinilm.h"
+#include "base/topk_softmax.h"
+
+#include <optional>
 
 namespace infinicore::op::topksoftmax_impl::infiniops {
 namespace {
 using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 struct PlannedMeta {
-    TensorMeta values, indices, x;
-    graph::GraphTensor values_tensor, indices_tensor, x_tensor;
-    size_t topk;
+    TensorMeta values, indices, token_expert_indices, x;
+    graph::GraphTensor values_tensor, indices_tensor, token_expert_indices_tensor, x_tensor;
     int norm;
 };
 } // namespace
@@ -19,7 +20,17 @@ struct PlannedMeta {
 void *plan(Tensor values, Tensor indices, const Tensor &x, const size_t topk, const int norm) {
     INFINICORE_ASSERT(::infinicore::op::infiniops::isSupportedDevice(values->device().getType()));
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(values, indices, x);
-    return new PlannedMeta{TensorMeta(values), TensorMeta(indices), TensorMeta(x), graph::GraphTensor(values), graph::GraphTensor(indices), graph::GraphTensor(x), topk, norm};
+    auto token_expert_indices = Tensor::empty({x->size(0), topk}, DataType::I32, indices->device());
+    return new PlannedMeta{
+        TensorMeta(values),
+        TensorMeta(indices),
+        TensorMeta(token_expert_indices),
+        TensorMeta(x),
+        graph::GraphTensor(values),
+        graph::GraphTensor(indices),
+        graph::GraphTensor(token_expert_indices),
+        graph::GraphTensor(x),
+        norm};
 }
 
 void run(void *planned_meta) {
@@ -27,14 +38,16 @@ void run(void *planned_meta) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    infini::ops::TopksoftmaxInfinilm::Call(
+    infini::ops::TopkSoftmax::Call(
         handle,
         config,
         planned->x.tensor(planned->x_tensor),
-        static_cast<int64_t>(planned->topk),
+        std::optional<infini::ops::Tensor>{},
+        std::optional<infini::ops::Tensor>{},
         planned->norm != 0,
         planned->values.tensor(planned->values_tensor),
-        planned->indices.tensor(planned->indices_tensor));
+        planned->indices.tensor(planned->indices_tensor),
+        planned->token_expert_indices.tensor(planned->token_expert_indices_tensor));
 }
 
 void cleanup(void **planned_meta_ptr) {


### PR DESCRIPTION
## What

- Replace the remaining covered InfiniLM-suffixed InfiniOps adapter calls with canonical InfiniOps APIs for activations, paged caching, top-k softmax, softmax, rearrange, and conv2d.
- Advance the InfiniOps submodule from `1b9c3765` to the common validated pin `21b07ebc`.
- Preserve all public InfiniCore operator signatures and keep each migration as a separate commit.

## Alignment

| InfiniCore adapter | Canonical InfiniOps call | Open-source alignment |
| --- | --- | --- |
| `gelu` | `Gelu(input, approximate="none", out)` | [PyTorch `torch.nn.functional.gelu`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.gelu.html), [InfiniOps API](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/gelu.h) |
| `gelutanh` | `Gelu(input, approximate="tanh", out)` | [PyTorch `torch.nn.functional.gelu`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.gelu.html), [InfiniOps #889](https://github.com/InfiniTensor/InfiniOps/pull/889) |
| `relu` | `Relu(input, out)` | [PyTorch `torch.nn.functional.relu`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.relu.html), [InfiniOps API](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/relu.h) |
| `sigmoid` | `Sigmoid(input, out)` | [PyTorch `torch.sigmoid`](https://docs.pytorch.org/docs/stable/generated/torch.sigmoid.html), [InfiniOps API](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/sigmoid.h) |
| `silu_and_mul` | `SiluAndMul(input, out)` | [vLLM `SiluAndMul`](https://docs.vllm.ai/en/stable/api/vllm/model_executor/layers/activation/#vllm.model_executor.layers.activation.SiluAndMul), [InfiniOps API](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/silu_and_mul.h) |
| `paged_caching` | `ReshapeAndCacheFlash(key, value, slot_mapping, k_scale, v_scale, "auto", key_cache, value_cache)` | [vLLM `reshape_and_cache_flash`](https://github.com/vllm-project/vllm/blob/568afb3a13806beb53bb2e6bd518269357b237c0/vllm/_custom_ops.py#L2521-L2540), [InfiniOps #883](https://github.com/InfiniTensor/InfiniOps/pull/883) |
| `topksoftmax` | `TopkSoftmax(gating_output, bias, is_padding, renormalize, topk_weights, topk_indices, token_expert_indices)` | [vLLM `topk_softmax`](https://github.com/vllm-project/vllm/blob/88402a41c4ab272ebbbd33f4a77fbbac0431cbb9/vllm/_custom_ops.py#L2385-L2413), [InfiniOps API](https://github.com/InfiniTensor/InfiniOps/blob/21b07ebcfdb0f993d2f3b672a4e38788e489fb80/src/base/topk_softmax.h) |
| `softmax` | `Softmax(input, dim, dtype=nullopt, out)` | [PyTorch `torch.nn.functional.softmax`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.softmax.html), [InfiniOps #890](https://github.com/InfiniTensor/InfiniOps/pull/890) |
| `rearrange` | `Copy(input, non_blocking=false, out)` | [PyTorch `Tensor.copy_`](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.copy_.html), [InfiniOps #872](https://github.com/InfiniTensor/InfiniOps/pull/872), [provider adaptation #897](https://github.com/InfiniTensor/InfiniOps/pull/897) |
| `conv2d` | `Convolution(input, weight, bias, stride, padding, dilation, false, output_padding=0, groups=1, out)` | [PyTorch `torch.nn.functional.conv2d`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.conv2d.html), [ATen `convolution` schema](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/native_functions.yaml), [InfiniOps #882](https://github.com/InfiniTensor/InfiniOps/pull/882) |

InfiniOps uses its C++ input/attribute/output ordering. Optional top-k softmax inputs are null because the current InfiniCore API does not expose them; the required auxiliary output is plan-owned internal storage. Paged caching uses metadata-only HND-to-NHD cache views and a persistent scalar scale tensor ignored by the current `auto` path.

## Scope

No public InfiniCore Python or C++ API changes are introduced. This consolidates the unique work from #1467, #1472, and #1476-#1479, and supersedes the earlier duplicate PRs #1468-#1471 and #1473.

The existing DeepSeek MLA paged-caching case with unequal key/value head sizes (576/512) remains unsupported by both the deprecated and canonical APIs. Extending that capability is outside this adapter-only migration.

Screenshots: N/A (backend adapter migration only).

## Validation

Run on `ssh nvidia` in `accelerator-dev/nvidia:latest` on NVIDIA A100 GPUs:

- clang-format 16.0.6 strict check passed for all 10 changed C++ files.
- `git diff --check origin/main..HEAD` passed.
- Unified InfiniOps build and `xmake install _infinicore` passed with legacy and canonical wrappers enabled together.
- Paged caching standard equal-head-size suite: 24/24 passed across FP16/BF16/FP32 and both cache layouts.
- Top-k softmax suite: 24/24 passed.
- Sigmoid suite: 45/45 passed.
- SiLU-and-mul suite: 36/36 passed.
- Conv2d suite: 12/12 passed.
