### PR TITLE
feat(metax): route basic Llama through canonical InfiniOps

### DIFF
--- a/src/infinicore/nn/rope.cc
+++ b/src/infinicore/nn/rope.cc
@@ -78,7 +78,7 @@ void RoPE::initialize_cache() {
     INFINICORE_NN_BUFFER_INIT(cos_cache, ({max_seq_len_, cache_dim}, dtype_, device_));
 
 #ifdef ENABLE_INFINIOPS_API
-    if (device_.getType() == Device::Type::NVIDIA && !mrope_section_) {
+    if ((device_.getType() == Device::Type::NVIDIA || device_.getType() == Device::Type::METAX) && !mrope_section_) {
         INFINICORE_NN_BUFFER_INIT(cos_sin_cache, ({max_seq_len_, rotary_dim_}, dtype_, device_));
     }
 #endif

--- a/src/infinicore/ops/random_sample/random_sample.cc
+++ b/src/infinicore/ops/random_sample/random_sample.cc
@@ -14,7 +14,9 @@ namespace {
 #ifdef ENABLE_INFINIOPS_API
 bool tryGreedyWithInfiniOps(Tensor indices, Tensor logits, int topk) {
     const auto dtype = logits->dtype();
-    if (logits->device().getType() != Device::Type::NVIDIA
+    const auto device_type = logits->device().getType();
+    if ((device_type != Device::Type::NVIDIA
+         && device_type != Device::Type::METAX)
         || topk != 1
         || logits->ndim() != 1
         || logits->numel() == 0

--- a/src/infinicore/ops/rotary_embedding/rotary_embedding_infiniops.cc
+++ b/src/infinicore/ops/rotary_embedding/rotary_embedding_infiniops.cc
@@ -31,7 +31,7 @@ void *plan(const Tensor &positions,
            bool is_neox,
            int64_t rope_dim_offset,
            bool inverse) {
-    INFINICORE_ASSERT(query->device().getType() == Device::Type::NVIDIA);
+    INFINICORE_ASSERT(query->device().getType() == Device::Type::NVIDIA || query->device().getType() == Device::Type::METAX);
     return new PlannedMeta{
         TensorMeta(positions),
         TensorMeta(query),
@@ -77,6 +77,9 @@ static bool registered = []() {
     RotaryEmbedding::plan_dispatcher().registerDevice(Device::Type::NVIDIA, &plan);
     RotaryEmbedding::run_dispatcher().registerDevice(Device::Type::NVIDIA, &run);
     RotaryEmbedding::cleanup_dispatcher().registerDevice(Device::Type::NVIDIA, &cleanup);
+    RotaryEmbedding::plan_dispatcher().registerDevice(Device::Type::METAX, &plan);
+    RotaryEmbedding::run_dispatcher().registerDevice(Device::Type::METAX, &run);
+    RotaryEmbedding::cleanup_dispatcher().registerDevice(Device::Type::METAX, &cleanup);
     return true;
 }();
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -416,7 +416,7 @@ local function build_infiniops_external(xmake_os)
         "-DGENERATE_PYTHON_BINDINGS=OFF",
         "-DCMAKE_BUILD_TYPE=Release"
     }
-    if has_config("nv-gpu") then
+    if has_config("nv-gpu") or has_config("metax-gpu") then
         table.insert(cmake_config_args, "-DWITH_TORCH=ON")
         table.insert(cmake_config_args, "-DINFINI_OPS_TORCH_OPS=argmax")
     end


### PR DESCRIPTION
## What

- Route the MetaX basic Llama/Qwen RoPE path through the canonical InfiniOps
  `RotaryEmbedding` API instead of the legacy InfiniOP RoPE C API.
- Enable the generated PyTorch `Argmax` provider in the external InfiniOps
  build on MetaX and use it for greedy sampling (`top_k=1`).
- Keep public InfiniCore C++ and Python interfaces unchanged.

## Migration

| InfiniCore route | Previous MetaX route | Canonical InfiniOps route | Alignment target |
| --- | --- | --- | --- |
| RoPE | Legacy `infiniopRoPE` C API | `RotaryEmbedding` MetaX provider | [vLLM `rotary_embedding`](https://github.com/vllm-project/vllm/blob/88402a41c4ab272ebbbd33f4a77fbbac0431cbb9/vllm/_custom_ops.py#L201-L225) |
| Greedy sampling (`top_k=1`) | Legacy random-sample path | Generated `Argmax` PyTorch provider | [PyTorch `torch.argmax`](https://docs.pytorch.org/docs/2.13/generated/torch.argmax.html) |

The other basic Llama routes were already migrated to canonical InfiniOps by
#1483. This PR adds the missing MetaX selection for the two routes above.

## Scope

This PR targets the basic Llama architecture path used by Qwen3 with paged
FlashAttention and greedy sampling on MetaX. Non-greedy sampling, other model
families, and other attention layouts remain out of scope.

This PR is stacked on the MetaX recurrent gated delta rule build fix because
that fix is required for a complete current-`main` MetaX build. The Llama
runtime changes themselves are independent.

Screenshots: N/A (backend integration only).

## Validation

Run on `ssh metax` in `infiniops-ci/metax:latest` on one MetaX C550, based on
`main` at `a12eb953` plus the stacked build fix:

- Full InfiniCore MetaX release build passed with `WITH_TORCH=ON` and the
  generated `argmax` wrapper enabled.
- `python3 test/infinicore/nn/rope.py --metax --debug` passed 6/6 cases.
- `python3 test/infinicore/ops/random_sample.py --metax --debug` passed 32/32
  cases, including FP16/BF16 `top_k=1` return-value and explicit-output cases.
- Qwen3-0.6B generated 64 greedy tokens and exited 0 with:

```bash
python3 examples/test_infer.py \
    --device=metax \
    --model=/workspace/Qwen3-0.6B \
    --enable-paged-attn \
    --attn=flash-attn \
    --disable-prefix-caching \
    --top-k=1 \
    --max-new-tokens=64
```

- An `LD_PRELOAD` trap covering the legacy InfiniOP execution entries used by
  the basic Transformer path did not fire during the 64-token prefill/decode
  run. The same trap reproduced the previous `infiniopRoPE` fallback before
  this change.
- Source scans found no InfiniLM-suffixed InfiniOps references in InfiniCore.
- The 64-token decoded output was unchanged from the pre-migration MetaX run.
- Against PyTorch Transformers greedy generation, the first 54 generated
  tokens matched exactly and token 55 diverged. This is an existing inference
  precision difference, not introduced by switching the MetaX RoPE route; the
  migration does not claim full token-for-token Transformers parity.
- `clang-format 16.0.6 --dry-run --Werror` and `git diff --check` passed.
