### PR TITLE
fix(metax): preload torch for MACA environments

### DIFF
--- a/python/infinicore/_preload.py
+++ b/python/infinicore/_preload.py
@@ -174,7 +174,7 @@ def _should_preload_device(device_type: str) -> bool:
     Check if preload is needed for a specific device type.
     """
     device_env_map = {
-        "METAX": ["HPCC_PATH", "INFINICORE_PRELOAD_HPCC"],  # HPCC/METAX
+        "METAX": ["MACA_PATH", "HPCC_PATH", "INFINICORE_PRELOAD_HPCC"],
         "HYGON": ["DTK_ROOT", "INFINICORE_PRELOAD_TORCH_HIP"],
         "ASCEND": ["ASCEND_HOME", "ASCEND_TOOLKIT_HOME"],
         "CAMBRICON": ["NEUWARE_HOME", "INFINICORE_PRELOAD_CAMBRICON"],


### PR DESCRIPTION
## What

- Recognize `MACA_PATH` as a MetaX environment marker in InfiniCore's Python
  preload logic.
- Reuse the existing MetaX preload path so `torch` is imported before the
  InfiniCore extension in current MACA environments.

## Why

The preload code only recognized the older `HPCC_PATH` marker. The current
MetaX image exports `MACA_PATH`, so importing `infinicore` or `infinilm`
directly loaded the extension before torch and terminated with a double free
during process teardown. Importing torch first avoided the failure.

This change only extends environment detection; it does not add a new preload
mechanism or change public APIs.

Screenshots: N/A (Python loader fix only).

## Validation

Run on `ssh metax` in `infiniops-ci/metax:latest` with
`MACA_PATH=/opt/maca`:

- A standalone process containing only `import infinicore` exited 0.
- A standalone process containing only `import infinilm` exited 0.
- Before this change, both direct-import processes terminated with exit code
  134 and a double-free report; `import torch` before either package avoided
  the failure.
- `ruff 0.15.22 check python/infinicore/_preload.py` passed.
- `ruff 0.15.22 format --check python/infinicore/_preload.py` passed.
- `git diff --check` passed.
