### PR TITLE
issue/1519 - fix Ascend paged attention block index name collision

### DIFF
--- a/src/infiniop/ops/paged_attention/ascend/paged_attention_ascend_kernel.cpp
+++ b/src/infiniop/ops/paged_attention/ascend/paged_attention_ascend_kernel.cpp
@@ -121,15 +121,15 @@ public:
         float max_score = -3.4028234663852886e38f;
         float sum_exp = 0.0f;
 
-        for (size_t block_idx = 0; block_idx < _max_num_blocks_per_seq; ++block_idx) {
-            size_t token_start = block_idx * _page_block_size;
+        for (size_t page_block_idx = 0; page_block_idx < _max_num_blocks_per_seq; ++page_block_idx) {
+            size_t token_start = page_block_idx * _page_block_size;
             if (token_start >= seq_len) {
                 break;
             }
 
             const int64_t physical_block = loadIndex(
                 _block_tables_gm,
-                static_cast<ptrdiff_t>(seq_idx) * _block_table_batch_stride + static_cast<ptrdiff_t>(block_idx));
+                static_cast<ptrdiff_t>(seq_idx) * _block_table_batch_stride + static_cast<ptrdiff_t>(page_block_idx));
 
             size_t token_end = token_start + _page_block_size;
             if (token_end > seq_len) {

--- a/src/infiniop/ops/paged_attention_prefill/ascend/paged_attention_prefill_ascend_kernel.cpp
+++ b/src/infiniop/ops/paged_attention_prefill/ascend/paged_attention_prefill_ascend_kernel.cpp
@@ -197,22 +197,22 @@ private:
     }
 
     __aicore__ inline ptrdiff_t keyBase(size_t seq_idx, size_t kv_head_idx, size_t token_idx) {
-        const size_t block_idx = token_idx / _page_block_size;
+        const size_t page_block_idx = token_idx / _page_block_size;
         const size_t token_offset = token_idx % _page_block_size;
         const int64_t physical_block = loadPrefillIndex(
             _block_tables_gm,
-            static_cast<ptrdiff_t>(seq_idx) * _block_table_batch_stride + static_cast<ptrdiff_t>(block_idx));
+            static_cast<ptrdiff_t>(seq_idx) * _block_table_batch_stride + static_cast<ptrdiff_t>(page_block_idx));
         return static_cast<ptrdiff_t>(physical_block) * _k_batch_stride
              + static_cast<ptrdiff_t>(kv_head_idx) * _k_head_stride
              + static_cast<ptrdiff_t>(token_offset) * _k_row_stride;
     }
 
     __aicore__ inline ptrdiff_t valueBase(size_t seq_idx, size_t kv_head_idx, size_t token_idx) {
-        const size_t block_idx = token_idx / _page_block_size;
+        const size_t page_block_idx = token_idx / _page_block_size;
         const size_t token_offset = token_idx % _page_block_size;
         const int64_t physical_block = loadPrefillIndex(
             _block_tables_gm,
-            static_cast<ptrdiff_t>(seq_idx) * _block_table_batch_stride + static_cast<ptrdiff_t>(block_idx));
+            static_cast<ptrdiff_t>(seq_idx) * _block_table_batch_stride + static_cast<ptrdiff_t>(page_block_idx));
         return static_cast<ptrdiff_t>(physical_block) * _v_batch_stride
              + static_cast<ptrdiff_t>(kv_head_idx) * _v_head_stride
              + static_cast<ptrdiff_t>(token_offset) * _v_row_stride;


### PR DESCRIPTION
## Related issue

Closes #1519 

## Summary

- Rename the logical paged-attention block index in the Ascend decode kernel.
- Rename the logical paged-attention block index in the Ascend prefill kernel.
- Avoid collision with the Ascend C built-in `block_idx` identifier.

## Root cause

Ascend C reserves `block_idx` as a compiler built-in variable.
The affected variables are logical page-block indices, not hardware
block IDs. The compiler therefore expands the declarations and reports
`illegal initializer`.

## Implementation

Renamed the local variables from `block_idx` to `page_block_idx`.

No algorithm, operator interface, indexing formula, memory layout, or
output behavior was changed.

## Testing

compile success

## Environment

- Hardware: Huawei Ascend 910B3
- CANN: 8.1.RC1
- OS: Linux