### PR TITLE
feat(hygon): enable Qwen3 inference with InfiniOps

### DIFF
--- a/src/infinicore/nn/rope.cc
+++ b/src/infinicore/nn/rope.cc
@@ -196,8 +196,12 @@ Tensor RoPE::forward(const Tensor &x, const Tensor &pos, bool in_place) const {
         if (!in_place) {
             y->copy_from(x);
         }
+        auto query = y;
+        if (pos->ndim() == 1 && query->ndim() == 4 && query->size(0) == 1) {
+            query = query->squeeze(0);
+        }
         op::rotary_embedding_(pos,
-                              y,
+                              query,
                               std::nullopt,
                               cos_sin_cache_,
                               static_cast<int64_t>(head_dim_),

--- a/src/infinicore/nn/rope.cc
+++ b/src/infinicore/nn/rope.cc
@@ -80,7 +80,8 @@ void RoPE::initialize_cache() {
 #ifdef ENABLE_INFINIOPS_API
     if ((device_.getType() == Device::Type::NVIDIA
          || device_.getType() == Device::Type::METAX
-         || device_.getType() == Device::Type::ILUVATAR)
+         || device_.getType() == Device::Type::ILUVATAR
+         || device_.getType() == Device::Type::HYGON)
         && !mrope_section_) {
         INFINICORE_NN_BUFFER_INIT(cos_sin_cache, ({max_seq_len_, rotary_dim_}, dtype_, device_));
     }

--- a/src/infinicore/ops/infiniops_impl.hpp
+++ b/src/infinicore/ops/infiniops_impl.hpp
@@ -55,6 +55,8 @@ inline infini::ops::Device toInfiniOpsDevice(const Device &device) {
         return infini::ops::Device{infini::ops::Device::Type::kMoore, static_cast<int>(device.getIndex())};
     case Device::Type::ILUVATAR:
         return infini::ops::Device{infini::ops::Device::Type::kIluvatar, static_cast<int>(device.getIndex())};
+    case Device::Type::HYGON:
+        return infini::ops::Device{infini::ops::Device::Type::kHygon, static_cast<int>(device.getIndex())};
     default:
         throw std::runtime_error("InfiniOps backend does not support this device type.");
     }
@@ -66,6 +68,7 @@ inline bool isSupportedDevice(Device::Type device_type) {
     case Device::Type::METAX:
     case Device::Type::MOORE:
     case Device::Type::ILUVATAR:
+    case Device::Type::HYGON:
         return true;
     default:
         return false;
@@ -78,6 +81,7 @@ void registerSupportedDevices(Dispatcher &dispatcher, Function function) {
     dispatcher.registerDevice(Device::Type::METAX, function);
     dispatcher.registerDevice(Device::Type::MOORE, function);
     dispatcher.registerDevice(Device::Type::ILUVATAR, function);
+    dispatcher.registerDevice(Device::Type::HYGON, function);
 }
 
 struct TensorMeta {

--- a/src/infinicore/ops/random_sample/random_sample.cc
+++ b/src/infinicore/ops/random_sample/random_sample.cc
@@ -5,6 +5,7 @@
 #if defined(ENABLE_INFINIOPS_API)    \
     && (defined(ENABLE_NVIDIA_API)   \
         || defined(ENABLE_METAX_API) \
+        || defined(ENABLE_HYGON_API) \
         || (defined(ENABLE_ILUVATAR_API) && defined(ENABLE_ATEN)))
 #include "../infiniops_impl.hpp"
 
@@ -17,13 +18,15 @@ namespace {
 #if defined(ENABLE_INFINIOPS_API)    \
     && (defined(ENABLE_NVIDIA_API)   \
         || defined(ENABLE_METAX_API) \
+        || defined(ENABLE_HYGON_API) \
         || (defined(ENABLE_ILUVATAR_API) && defined(ENABLE_ATEN)))
 bool tryGreedyWithInfiniOps(Tensor indices, Tensor logits, int topk) {
     const auto dtype = logits->dtype();
     const auto device_type = logits->device().getType();
     if ((device_type != Device::Type::NVIDIA
          && device_type != Device::Type::METAX
-         && device_type != Device::Type::ILUVATAR)
+         && device_type != Device::Type::ILUVATAR
+         && device_type != Device::Type::HYGON)
         || topk != 1
         || logits->ndim() != 1
         || logits->numel() == 0
@@ -38,7 +41,9 @@ bool tryGreedyWithInfiniOps(Tensor indices, Tensor logits, int topk) {
     infini::ops::Handle handle;
     handle.set_stream(context::getStream());
     infini::ops::Config config;
-    config.set_implementation_index(8);
+    if (device_type != Device::Type::HYGON) {
+        config.set_implementation_index(8);
+    }
     const std::optional<int64_t> no_dim;
     infini::ops::Argmax::Call(
         handle,
@@ -66,6 +71,7 @@ void RandomSample::execute(
 #if defined(ENABLE_INFINIOPS_API)    \
     && (defined(ENABLE_NVIDIA_API)   \
         || defined(ENABLE_METAX_API) \
+        || defined(ENABLE_HYGON_API) \
         || (defined(ENABLE_ILUVATAR_API) && defined(ENABLE_ATEN)))
     if (tryGreedyWithInfiniOps(indices, logits, topk)) {
         return;

--- a/src/infinicore/ops/rotary_embedding/rotary_embedding_infiniops.cc
+++ b/src/infinicore/ops/rotary_embedding/rotary_embedding_infiniops.cc
@@ -34,7 +34,8 @@ void *plan(const Tensor &positions,
     const auto device_type = query->device().getType();
     INFINICORE_ASSERT(device_type == Device::Type::NVIDIA
                       || device_type == Device::Type::METAX
-                      || device_type == Device::Type::ILUVATAR);
+                      || device_type == Device::Type::ILUVATAR
+                      || device_type == Device::Type::HYGON);
     return new PlannedMeta{
         TensorMeta(positions),
         TensorMeta(query),
@@ -86,6 +87,9 @@ static bool registered = []() {
     RotaryEmbedding::plan_dispatcher().registerDevice(Device::Type::ILUVATAR, &plan);
     RotaryEmbedding::run_dispatcher().registerDevice(Device::Type::ILUVATAR, &run);
     RotaryEmbedding::cleanup_dispatcher().registerDevice(Device::Type::ILUVATAR, &cleanup);
+    RotaryEmbedding::plan_dispatcher().registerDevice(Device::Type::HYGON, &plan);
+    RotaryEmbedding::run_dispatcher().registerDevice(Device::Type::HYGON, &run);
+    RotaryEmbedding::cleanup_dispatcher().registerDevice(Device::Type::HYGON, &cleanup);
     return true;
 }();
 

--- a/src/infinicore/ops/select_last_token_hidden/select_last_token_hidden_infiniops.cc
+++ b/src/infinicore/ops/select_last_token_hidden/select_last_token_hidden_infiniops.cc
@@ -78,6 +78,9 @@ static bool registered = []() {
     SelectLastTokenHidden::plan_dispatcher().registerDevice(Device::Type::METAX, &plan);
     SelectLastTokenHidden::run_dispatcher().registerDevice(Device::Type::METAX, &run);
     SelectLastTokenHidden::cleanup_dispatcher().registerDevice(Device::Type::METAX, &cleanup);
+    SelectLastTokenHidden::plan_dispatcher().registerDevice(Device::Type::HYGON, &plan);
+    SelectLastTokenHidden::run_dispatcher().registerDevice(Device::Type::HYGON, &run);
+    SelectLastTokenHidden::cleanup_dispatcher().registerDevice(Device::Type::HYGON, &cleanup);
     return true;
 }();
 

--- a/test/infinicore/nn/rope.py
+++ b/test/infinicore/nn/rope.py
@@ -169,9 +169,11 @@ class OpTest(BaseOperatorTest):
             torch_device = "cuda"
 
         # 创建 pos_ids的变量
-        pos_ids_torch = torch.arange(0, seq_len, dtype=torch.int32, device=torch_device)
+        pos_ids_torch = torch.arange(0, seq_len, dtype=torch.int64, device=torch_device)
         pos_ids_torch = pos_ids_torch.unsqueeze(0)
         pos_ids_torch = pos_ids_torch.expand(bs, seq_len).contiguous()
+        if bs == 1:
+            pos_ids_torch = pos_ids_torch.view(seq_len)
 
         pos_ids_infini = infinicore.from_torch(pos_ids_torch)
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -450,8 +450,9 @@ local function get_infiniops_backend_cmake_arg()
     add_backend("metax-gpu", "-DWITH_METAX=ON")
     add_backend("iluvatar-gpu", "-DWITH_ILUVATAR=ON")
     add_backend("moore-gpu", "-DWITH_MOORE=ON")
+    add_backend("hygon-dcu", "-DWITH_HYGON=ON")
     if #enabled == 0 then
-        raise("InfiniOps integration requires one of --nv-gpu, --metax-gpu, --iluvatar-gpu, or --moore-gpu")
+        raise("InfiniOps integration requires one of --nv-gpu, --metax-gpu, --iluvatar-gpu, --moore-gpu, or --hygon-dcu")
     end
     if #enabled > 1 then
         raise("InfiniOps can build only one GPU backend at a time")
@@ -478,10 +479,11 @@ local function build_infiniops_external(xmake_os, json)
     }
     if has_config("nv-gpu")
         or has_config("metax-gpu")
+        or has_config("hygon-dcu")
         or (has_config("iluvatar-gpu") and has_config("aten")) then
         table.insert(cmake_config_args, "-DWITH_TORCH=ON")
         local torch_ops = "argmax"
-        if has_config("nv-gpu") or has_config("metax-gpu") then
+        if has_config("nv-gpu") or has_config("metax-gpu") or has_config("hygon-dcu") then
             torch_ops = torch_ops .. ",index_select"
         end
         table.insert(cmake_config_args, "-DINFINI_OPS_TORCH_OPS=" .. torch_ops)


### PR DESCRIPTION
## Summary

- enable the Hygon backend for external InfiniOps integration
- register Hygon as a supported InfiniOps device in InfiniCore
- route greedy sampling through canonical InfiniOps `Argmax`
- route Hygon RoPE through canonical InfiniOps `RotaryEmbedding`
- normalize the singleton-batch RoPE shape required by the canonical API
- exclude InfiniOps adapters whose required Hygon providers are not available yet

## Motivation

InfiniCore could previously build its legacy operators for Hygon, but the
external InfiniOps integration did not recognize Hygon as a supported backend.
This prevented InfiniLM Qwen3 inference from routing the required model
operators through InfiniOps backed by standalone InfiniRT.

This PR adds the InfiniCore-side Hygon integration. The corresponding Hygon
native providers are supplied by the companion InfiniOps PR.

## Dependency

Depends on:

- InfiniTensor/InfiniOps#947

InfiniRT and InfiniLM require no source changes.

## Validation

Tested on a Hygon `gfx936` device with:

- standalone InfiniRT built with `WITH_CPU=ON` and `WITH_HYGON=ON`
- external InfiniOps repository
- `graph=false`
- `ccl=false`
- `aten=false`
- FlashAttention disabled
- `INFINI_OPS_OPS` unset

InfiniCore and its Python extension built and installed successfully.

The canonical SwiGLU path (`Copy + SiluAndMul`) was compared against PyTorch
with FP16, FP32 and BF16, including contiguous, strided and in-place outputs.
All 12 cases passed.

Qwen3-0.6B inference completed successfully with Static KV Cache and
`enable_graph=False`:

```bash
python3 examples/test_infer.py \
  --device hygon \
  --model=/data-aisoft/mechdancer/models/Qwen3-0.6B