### PR TITLE
fix(build): filter InfiniOps adapters on every backend

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -880,21 +880,21 @@ target("infinicore_cpp_api")
                     path.join(torch_mlu_dir, "csrc"),
                     path.join(torch_mlu_dir, "csrc", "include"),
                     {public = true})
+            end
 
-                if selected_ops then
-                    for _, adapter_file in ipairs(os.files("src/infinicore/ops/*/*_infiniops.cc")) do
-                        local adapter_name =
-                            path.filename(adapter_file):match("^(.-)_infiniops%.cc$")
-                        if not is_infiniops_adapter_selected(adapter_name,
-                                                              selected_ops) then
-                            target:remove("files", adapter_file)
-                        end
+            if selected_ops then
+                for _, adapter_file in ipairs(os.files("src/infinicore/ops/*/*_infiniops.cc")) do
+                    local adapter_name =
+                        path.filename(adapter_file):match("^(.-)_infiniops%.cc$")
+                    if not is_infiniops_adapter_selected(adapter_name,
+                                                         selected_ops) then
+                        target:remove("files", adapter_file)
                     end
-                else
-                    target:remove(
-                        "files",
-                        "src/infinicore/ops/paged_attention/paged_attention_infiniops.cc")
                 end
+            else
+                target:remove(
+                    "files",
+                    "src/infinicore/ops/paged_attention/paged_attention_infiniops.cc")
             end
         end)
         after_install(function (target)


### PR DESCRIPTION
## Summary

- apply `INFINI_OPS_OPS` adapter filtering on every backend instead of only inside the Cambricon + ATen setup block
- keep the Cambricon-specific `torch_mlu` ABI and include configuration scoped to Cambricon
- preserve the existing fallback that excludes the paged-attention InfiniOps adapter when no operator selection is provided

## Root cause

The adapter-filtering block was nested in the Cambricon + ATen condition, so NVIDIA and other backends compiled every `*_infiniops.cc` adapter even when `ops.json` selected only a subset. A linked InfiniOps library could then fail to load because an unselected adapter retained an unresolved operator reference.

## Validation

- `git diff --check`
- exercised this exact change in the stacked NVIDIA validation using `accelerator-dev/nvidia:latest` and an `ops.json`-selected InfiniOps build
- confirmed the unselected `IndexSelect` adapter no longer left an undefined InfiniOps reference
- built and installed `infinicore_cpp_api` and `_infinicore`; the resulting Python package imported successfully

