### PR TITLE
fix: retain select last token InfiniOps adapter

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -492,6 +492,7 @@ local infiniops_adapter_dependencies = {
     paged_attention = {"flash_attn_with_kvcache"},
     paged_caching = {"reshape_and_cache_flash"},
     rearrange = {"copy"},
+    select_last_token_hidden = {"add", "index_select"},
     topksoftmax = {"topk_softmax"}
 }
 


### PR DESCRIPTION
## Summary

- declare `add` and `index_select` as the InfiniOps dependencies of the composed `select_last_token_hidden` adapter
- retain that adapter when both aligned operators are selected through `ops.json`

## Impact

Without an explicit dependency mapping, adapter filtering treats `select_last_token_hidden` as a direct InfiniOps operator. Since the aligned implementation is composed from `add` and `index_select`, the filter removes it and InfiniCore falls back to the legacy InfiniOp implementation even when both required InfiniOps operators are available.

This change only corrects source selection. It does not modify the adapter implementation, operator interfaces, or submodules.

## Validation

- `git diff --check`
- validated from InfiniRT `6b256e0ab085`, InfiniOps `c8e15ebe9da4`, InfiniCore `847c4c04fe18` plus this change, and InfiniLM `80bb09ecebc9`
- built and installed InfiniRT and InfiniOps independently, then configured InfiniCore as an installed-package consumer on NVIDIA and MetaX
- ran Qwen3-0.6B paged-attention inference with greedy decoding on both platforms
- NVIDIA temporary route instrumentation reported only `SELECT_ROUTE=infiniops` for `select_last_token_hidden`
- MetaX GDB route counts reported `select_infiniops=1`, `select_infiniop=0`, and `random_infiniop=0`; aligned Argmax and linked flash-attention providers were exercised
