### PR TITLE
issue/1541 - feat: enable InfiniOps dispatch for ALI devices

### DIFF
--- a/src/infinicore/ops/infiniops_impl.hpp
+++ b/src/infinicore/ops/infiniops_impl.hpp
@@ -61,6 +61,8 @@ inline infini::ops::Device toInfiniOpsDevice(const Device &device) {
         return infini::ops::Device{infini::ops::Device::Type::kHygon, static_cast<int>(device.getIndex())};
     case Device::Type::ASCEND:
         return infini::ops::Device{infini::ops::Device::Type::kAscend, static_cast<int>(device.getIndex())};
+    case Device::Type::ALI:
+        return infini::ops::Device{infini::ops::Device::Type::kThead, static_cast<int>(device.getIndex())};
     default:
         throw std::runtime_error("InfiniOps backend does not support this device type.");
     }
@@ -75,6 +77,7 @@ inline bool isSupportedDevice(Device::Type device_type) {
     case Device::Type::CAMBRICON:
     case Device::Type::HYGON:
     case Device::Type::ASCEND:
+    case Device::Type::ALI:
         return true;
     default:
         return false;
@@ -90,6 +93,7 @@ void registerSupportedDevices(Dispatcher &dispatcher, Function function) {
     dispatcher.registerDevice(Device::Type::CAMBRICON, function);
     dispatcher.registerDevice(Device::Type::HYGON, function);
     dispatcher.registerDevice(Device::Type::ASCEND, function);
+    dispatcher.registerDevice(Device::Type::ALI, function);
 }
 
 struct TensorMeta {


### PR DESCRIPTION
Maps InfiniCore ALI devices to the Thead InfiniOps backend and enables ALI device registration for InfiniOps dispatch. This allows PPU operators to run through the InfiniOps integration path.