### PR TITLE
fix(kunlun): memset fallback, graph-op destructor UB, missing selectlast_token_hidden kernel

### DIFF
--- a/include/infinicore/graph/graph.hpp
+++ b/include/infinicore/graph/graph.hpp
@@ -50,9 +50,13 @@ protected:
     }
     using run_schema = void (*)(void *);
     using cleanup_schema = void (*)(void **);
-    void *planned_meta_;
-    run_schema runner_;
-    cleanup_schema deleter_;
+    // These must be default-initialized: if a derived constructor throws
+    // (e.g. the operator is not supported on the current device), the base
+    // destructor still runs during stack unwinding and would otherwise read
+    // uninitialized pointers.
+    void *planned_meta_ = nullptr;
+    run_schema runner_ = nullptr;
+    cleanup_schema deleter_ = nullptr;
     graph_replay_schema graph_replay_ = nullptr;
 };
 

--- a/src/infinicore/ops/cat/cat.cc
+++ b/src/infinicore/ops/cat/cat.cc
@@ -131,7 +131,7 @@ Tensor cat(std::vector<Tensor> tensors, int dim) {
 
     Shape shape = tensors[0]->shape();
     for (int i = 1; i < tensors.size(); i++) {
-        assert(tensors[i]->ndim() == dim || tensors[i]->ndim() == 1);
+        assert(tensors[i]->ndim() == ndim || tensors[i]->ndim() == 1);
         if (tensors[i]->ndim() != ndim) {
             continue;
         }
@@ -152,7 +152,7 @@ void cat_(Tensor out, std::vector<Tensor> tensors, int dim) {
 
     size_t dim_shape = 0;
     for (auto &tensor : tensors) {
-        assert(tensor->ndim() == ndim || tensors[i]->ndim() == 1);
+        assert(tensor->ndim() == ndim || tensor->ndim() == 1);
         if (tensor->ndim() == 1) {
             assert(tensor->shape()[0] == 0);
             continue;

--- a/src/infiniop/ops/select_last_token_hidden/kunlun/select_last_token_hidden_kunlun.h
+++ b/src/infiniop/ops/select_last_token_hidden/kunlun/select_last_token_hidden_kunlun.h
@@ -1,0 +1,8 @@
+#ifndef __SELECT_LAST_TOKEN_HIDDEN_KUNLUN_H__
+#define __SELECT_LAST_TOKEN_HIDDEN_KUNLUN_H__
+
+#include "../select_last_token_hidden.h"
+
+DESCRIPTOR(kunlun)
+
+#endif // __SELECT_LAST_TOKEN_HIDDEN_KUNLUN_H__

--- a/src/infiniop/ops/select_last_token_hidden/kunlun/select_last_token_hidden_kunlun.xpu
+++ b/src/infiniop/ops/select_last_token_hidden/kunlun/select_last_token_hidden_kunlun.xpu
@@ -1,0 +1,151 @@
+#include "../../../../utils.h"
+#include "../../../devices/kunlun/kunlun_common.h"
+#include "../../../devices/kunlun/kunlun_handle.h"
+#include "../../../devices/kunlun/kunlun_kernel_common.h"
+#include "../../../tensor.h"
+#include "select_last_token_hidden_kunlun.h"
+
+using namespace device::kunlun::kernel;
+
+template <typename T>
+__global__ void selectLastTokenHiddenKernel(
+    __global_ptr__ T *output,
+    __global_ptr__ const T *hidden_states,
+    __global_ptr__ const int32_t *input_offsets,
+    uint32_t total_tokens,
+    uint32_t num_requests,
+    uint32_t row_elems) {
+
+    int cid = core_id();
+    int ncores = core_num();
+    if (cid >= ncores) {
+        return;
+    }
+
+    int thread_id = ncores * cluster_id() + cid;
+    int nthreads = ncores * cluster_num();
+
+    // num_requests * row_elems (the total number of output elements) can
+    // exceed 32 bits, so index in 64 bits to avoid wrap-around.
+    uint64_t total_size = static_cast<uint64_t>(num_requests) * row_elems;
+    for (uint64_t linear = thread_id; linear < total_size; linear += nthreads) {
+        uint64_t request = linear / row_elems;
+        uint64_t dim = linear - request * row_elems;
+        int32_t row = input_offsets[request + 1] - 1;
+
+        if (row >= 0 && static_cast<uint64_t>(row) < static_cast<uint64_t>(total_tokens)) {
+            __local__ T value;
+            GM2LM_ASYNC(hidden_states + static_cast<uint64_t>(row) * row_elems + dim, &value, sizeof(T));
+            mfence();
+            LM2GM_ASYNC(&value, output + linear, sizeof(T));
+        }
+    }
+}
+
+namespace op::select_last_token_hidden::kunlun {
+
+struct Descriptor::Opaque {
+    infiniDtype_t hidden_dtype;
+};
+
+Descriptor::~Descriptor() {
+    delete _opaque;
+}
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle,
+    Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t output_desc,
+    infiniopTensorDescriptor_t hidden_states_desc,
+    infiniopTensorDescriptor_t input_offsets_desc) {
+    const auto output_shape = output_desc->shape();
+    const auto hidden_shape = hidden_states_desc->shape();
+    const auto offsets_shape = input_offsets_desc->shape();
+
+    CHECK_OR_RETURN(output_shape.size() == 3 && hidden_shape.size() == 3 && offsets_shape.size() == 1,
+                    INFINI_STATUS_BAD_TENSOR_SHAPE);
+    CHECK_OR_RETURN(offsets_shape[0] >= 2, INFINI_STATUS_BAD_TENSOR_SHAPE);
+    const size_t num_requests = offsets_shape[0] - 1;
+    CHECK_OR_RETURN(output_shape[0] == 1 && output_shape[1] == num_requests
+                        && output_shape[2] == hidden_shape[2],
+                    INFINI_STATUS_BAD_TENSOR_SHAPE);
+    CHECK_OR_RETURN(output_desc->isContiguous() && hidden_states_desc->isContiguous()
+                        && input_offsets_desc->isContiguous(),
+                    INFINI_STATUS_BAD_TENSOR_STRIDES);
+    CHECK_OR_RETURN(input_offsets_desc->dtype() == INFINI_DTYPE_I32,
+                    INFINI_STATUS_BAD_TENSOR_DTYPE);
+    const auto hidden_dtype = hidden_states_desc->dtype();
+    CHECK_OR_RETURN(hidden_dtype == INFINI_DTYPE_F16 || hidden_dtype == INFINI_DTYPE_BF16
+                        || hidden_dtype == INFINI_DTYPE_F32,
+                    INFINI_STATUS_BAD_TENSOR_DTYPE);
+    CHECK_OR_RETURN(output_desc->dtype() == hidden_dtype, INFINI_STATUS_BAD_TENSOR_DTYPE);
+
+    const size_t total_tokens = hidden_shape[0] * hidden_shape[1];
+    CHECK_OR_RETURN(total_tokens > 0 && hidden_shape[2] > 0, INFINI_STATUS_BAD_TENSOR_SHAPE);
+    *desc_ptr = new Descriptor(
+        num_requests,
+        total_tokens,
+        hidden_shape[2] * infiniSizeOf(hidden_dtype),
+        new Opaque{hidden_dtype},
+        handle->device,
+        handle->device_id,
+        hidden_shape[2]);
+    return INFINI_STATUS_SUCCESS;
+}
+
+template <typename T>
+infiniStatus_t launchSelectLastTokenHidden(
+    void *output,
+    const void *hidden_states,
+    const void *input_offsets,
+    size_t total_tokens,
+    size_t num_requests,
+    size_t row_elems,
+    kunlunStream_t stream) {
+
+    if (total_tokens > static_cast<size_t>(UINT32_MAX) || num_requests > static_cast<size_t>(UINT32_MAX) || row_elems > static_cast<size_t>(UINT32_MAX)) {
+        return INFINI_STATUS_BAD_TENSOR_SHAPE;
+    }
+
+    selectLastTokenHiddenKernel<T><<<12, 64, stream>>>(
+        reinterpret_cast<__global_ptr__ T *>(output),
+        reinterpret_cast<__global_ptr__ const T *>(hidden_states),
+        reinterpret_cast<__global_ptr__ const int32_t *>(input_offsets),
+        static_cast<uint32_t>(total_tokens),
+        static_cast<uint32_t>(num_requests),
+        static_cast<uint32_t>(row_elems));
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(
+    void *output,
+    const void *hidden_states,
+    const void *input_offsets,
+    void *stream) const {
+
+    if (_num_requests == 0) {
+        return INFINI_STATUS_SUCCESS;
+    }
+
+    auto kunlun_stream = reinterpret_cast<kunlunStream_t>(stream);
+
+    switch (_opaque->hidden_dtype) {
+    case INFINI_DTYPE_F16:
+        return launchSelectLastTokenHidden<half>(
+            output, hidden_states, input_offsets,
+            _total_tokens, _num_requests, _kernel_dim_x, kunlun_stream);
+    case INFINI_DTYPE_BF16:
+        return launchSelectLastTokenHidden<bfloat16_t>(
+            output, hidden_states, input_offsets,
+            _total_tokens, _num_requests, _kernel_dim_x, kunlun_stream);
+    case INFINI_DTYPE_F32:
+        return launchSelectLastTokenHidden<float>(
+            output, hidden_states, input_offsets,
+            _total_tokens, _num_requests, _kernel_dim_x, kunlun_stream);
+    default:
+        return INFINI_STATUS_BAD_TENSOR_DTYPE;
+    }
+}
+
+} // namespace op::select_last_token_hidden::kunlun

--- a/src/infiniop/ops/select_last_token_hidden/operator.cc
+++ b/src/infiniop/ops/select_last_token_hidden/operator.cc
@@ -20,6 +20,9 @@
 #ifdef ENABLE_ASCEND_API
 #include "ascend/select_last_token_hidden_ascend.h"
 #endif
+#ifdef ENABLE_KUNLUN_API
+#include "kunlun/select_last_token_hidden_kunlun.h"
+#endif
 
 __INFINI_C infiniStatus_t infiniopCreateSelectLastTokenHiddenDescriptor(
     infiniopHandle_t handle,
@@ -65,6 +68,9 @@ __INFINI_C infiniStatus_t infiniopCreateSelectLastTokenHiddenDescriptor(
 #endif
 #ifdef ENABLE_ASCEND_API
         CREATE(INFINI_DEVICE_ASCEND, ascend);
+#endif
+#ifdef ENABLE_KUNLUN_API
+        CREATE(INFINI_DEVICE_KUNLUN, kunlun);
 #endif
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
@@ -116,6 +122,9 @@ __INFINI_C infiniStatus_t infiniopSelectLastTokenHidden(
 #ifdef ENABLE_ASCEND_API
         CALCULATE(INFINI_DEVICE_ASCEND, ascend);
 #endif
+#ifdef ENABLE_KUNLUN_API
+        CALCULATE(INFINI_DEVICE_KUNLUN, kunlun);
+#endif
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
     }
@@ -161,6 +170,9 @@ __INFINI_C infiniStatus_t infiniopDestroySelectLastTokenHiddenDescriptor(
 #endif
 #ifdef ENABLE_ASCEND_API
         DESTROY(INFINI_DEVICE_ASCEND, ascend);
+#endif
+#ifdef ENABLE_KUNLUN_API
+        DESTROY(INFINI_DEVICE_KUNLUN, kunlun);
 #endif
     default:
         return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;

--- a/src/infinirt/kunlun/infinirt_kunlun.cc
+++ b/src/infinirt/kunlun/infinirt_kunlun.cc
@@ -1,6 +1,9 @@
 #include "infinirt_kunlun.h"
 #include "../../utils.h"
+#include <algorithm>
 #include <cstring>
+#include <mutex>
+#include <vector>
 #include <xpu/runtime.h>
 #include <xpu/runtime_ex.h>
 
@@ -98,12 +101,67 @@ infiniStatus_t freeDevice(void *ptr) {
     return INFINI_STATUS_SUCCESS;
 }
 
+namespace {
+// The Kunlun XRE runtime exposes no memset API, so emulate it with H2D
+// copies from a host staging buffer filled with the requested byte value.
+// The copy is chunked so that large fills (e.g. a multi-GB KV cache) only
+// need a bounded amount of host memory.
+constexpr size_t MEMSET_STAGING_BYTES = 16ULL * 1024 * 1024;
+
+std::mutex memset_staging_mutex;
+std::vector<uint8_t> memset_staging_buffer;
+
+infiniStatus_t memsetViaCopy(void *ptr, int value, size_t count,
+                             kunlunStream_t stream, bool is_async) {
+    if (count == 0) {
+        return INFINI_STATUS_SUCCESS;
+    }
+
+    std::lock_guard<std::mutex> lock(memset_staging_mutex);
+
+    size_t chunk = std::min(count, MEMSET_STAGING_BYTES);
+    if (memset_staging_buffer.size() < chunk) {
+        memset_staging_buffer.resize(chunk);
+    }
+    std::memset(memset_staging_buffer.data(), value, chunk);
+
+    auto dst = static_cast<uint8_t *>(ptr);
+    for (size_t done = 0; done < count;) {
+        size_t n = std::min(chunk, count - done);
+        if (is_async) {
+            // Always enqueue on `stream` (or the default stream if stream is
+            // nullptr) so the fill is properly ordered with respect to work
+            // already queued there; a plain xpu_memcpy would bypass the stream.
+            CHECK_KUNLUNRT(xpu_memcpy_async(dst + done, memset_staging_buffer.data(),
+                                            static_cast<uint64_t>(n), XPUMemcpyKind::XPU_HOST_TO_DEVICE, stream));
+        } else {
+            CHECK_KUNLUNRT(xpu_memcpy(dst + done, memset_staging_buffer.data(),
+                                      static_cast<uint64_t>(n), XPUMemcpyKind::XPU_HOST_TO_DEVICE));
+        }
+        done += n;
+    }
+
+    if (is_async) {
+        // The staging buffer is shared and refilled by the next call; wait for
+        // the async copies to finish reading it before unlocking.
+        if (stream) {
+            CHECK_KUNLUNRT(xpu_wait(stream));
+        } else {
+            CHECK_KUNLUNRT(xpu_wait());
+        }
+    }
+    return INFINI_STATUS_SUCCESS;
+}
+} // namespace
+
 infiniStatus_t memsetDevice(void *ptr, int value, size_t count) {
-    return INFINI_STATUS_NOT_IMPLEMENTED;
+    return memsetViaCopy(ptr, value, count, nullptr, false);
 }
 
 infiniStatus_t memsetDeviceAsync(void *ptr, int value, size_t count, infinirtStream_t stream) {
-    return INFINI_STATUS_NOT_IMPLEMENTED;
+    // XRE has no async memset primitive, so emulate it with copies; they must
+    // still be issued on `stream` to preserve stream ordering.
+    return memsetViaCopy(ptr, value, count, (kunlunStream_t)stream, true);
 }
 
 infiniStatus_t freeHost(void *ptr) {


### PR DESCRIPTION


  Kunlun inference was broken by three independent issues; this commit
  fixes all of them.

  1. Kunlun memset support (src/infinirt/kunlun/infinirt_kunlun.cc)

  memsetDevice/memsetDeviceAsync returned INFINI_STATUS_NOT_IMPLEMENTED.
  This surfaced after fafd7238 (issue/1170), which made Tensor::zeros
  actually zero the buffer via memset; previously the buffer from empty()
  was left untouched, so the stub was never exercised. XRE exposes no
  memset API, so emulate it with chunked host-to-device copies from a
  16 MiB host staging buffer, keeping host memory bounded regardless of
  fill size. The async variant falls back to the sync copy, consistent
  with mallocAsync/freeAsync already falling back to sync XRE calls.

  2. Uninitialized DispatchableGraphOperator members (include/infinicore/graph/graph.hpp)

  planned_meta_/runner_/deleter_ had no default initializers. When a
  derived constructor throws (e.g. an operator unsupported on the current
  device), stack unwinding still runs the base destructor, which read the
  garbage deleter_ and jumped through it - a silent SIGSEGV that masked
  the real "operator not supported" error and made the process exit with
  no traceback. Default-initialize all three to nullptr so the existing
  null check in the destructor skips cleanup safely. No functional change
  for already-supported devices: every constructor overwrites the three
  members via INFINICORE_GRAPH_OP_DISPATCH before they are read.

  3. Kunlun kernel for select_last_token_hidden for already-supported devices: every constructor overwrites the three members via INFINICORE_GRAPH_OP_DISPATCH before they are read.

  3. Kunlun kernel for select_last_token_hidden

  Add an XPU kernel (f16/bf16/f32) and register it in the infiniop
  dispatcher, unblocking the static-cache path on Kunlun. The build picks
  the new files up through the existing ops/*/kunlun/*.xpu glob; no build
  change needed. Note that paged_caching/paged_attention still have no
  Kunlun kernels, so --enable-paged-attn remains unsupported on this
  platform for now.

  Also fix an out-of-scope index in a cat.cc assert (tensors[i] -> tensor,
  where no such i exists in that loop), which broke debug builds.


当前最新代码仓上昆仑芯推理报错：
<img width="1880" height="828" alt="image" src="https://github.com/user-attachments/assets/d001f088-3098-4717-a3c0-1744793d652e" />

还会有跟graph相关的coredump，堆栈如下：
<img width="1895" height="909" alt="image" src="https://github.com/user-attachments/assets/90f5a0f4-9de8-40f1-80bc-2f848e7ac33c" />
<img width="1860" height="702" alt="image" src="https://github.com/user-attachments/assets/fead0884-8a3c-47fa-bdc2-b4141d4e5da9" />


修复后验证：
python examples/test_infer.py --device kunlun --model=/mnt/geogpt-doc-new/default/infinilm-models/Qwen3-0.6B --tp 1 --batch-size 1 --prompt "who are you"

<img width="1849" height="849" alt="image" src="https://github.com/user-attachments/assets/c29ce43e-a2e2-420c-87f7-0cd962ca1466" />
