### PR TITLE
feat: fix the ATen compilation of torch 2.11 on the Hygon platform

### DIFF
--- a/include/infinicore/adaptor/aten_adaptor.hpp
+++ b/include/infinicore/adaptor/aten_adaptor.hpp
@@ -26,6 +26,16 @@
 #include <c10/musa/MUSAStream.h>
 #endif
 
+#if defined(ENABLE_HYGON_API)
+#if __has_include(<torch/version.h>)
+#include <torch/version.h>
+#define INFINICORE_TORCH_VERSION_GE_2_11 \
+    (TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 11))
+#else
+#define INFINICORE_TORCH_VERSION_GE_2_11 0
+#endif
+#endif
+
 namespace infinicore::adaptor {
 inline at::ScalarType to_at_dtype(DataType dtype) {
     switch (dtype) {
@@ -84,7 +94,11 @@ inline at::Device to_at_device(const Device &device) {
 at::Tensor to_aten_tensor(const infinicore::Tensor &t);
 
 #if defined(ENABLE_HYGON_API)
+#if INFINICORE_TORCH_VERSION_GE_2_11
+c10::cuda::CUDAStream get_hip_stream();
+#else
 c10::hip::HIPStream get_hip_stream();
+#endif
 #elif defined(ENABLE_NVIDIA_API) || defined(ENABLE_METAX_API) || defined(ENABLE_QY_API) || defined(ENABLE_ALI_API)
 c10::cuda::CUDAStream get_cuda_stream();
 #endif

--- a/src/infinicore/adaptor/aten_adaptor.cc
+++ b/src/infinicore/adaptor/aten_adaptor.cc
@@ -121,10 +121,17 @@ at::Tensor to_aten_tensor(const infinicore::Tensor &t) {
 }
 
 #if defined(ENABLE_HYGON_API)
+#if INFINICORE_TORCH_VERSION_GE_2_11
+c10::cuda::CUDAStream get_hip_stream() {
+    return c10::cuda::getStreamFromExternal(
+        hipStream_t(infinicore::context::getStream()), infinicore::context::getDevice().getIndex());
+}
+#else
 c10::hip::HIPStream get_hip_stream() {
     return c10::hip::getStreamFromExternal(
         hipStream_t(infinicore::context::getStream()), infinicore::context::getDevice().getIndex());
 }
+#endif
 #elif defined(ENABLE_NVIDIA_API) || defined(ENABLE_METAX_API) || defined(ENABLE_QY_API) || defined(ENABLE_ALI_API)
 c10::cuda::CUDAStream get_cuda_stream() {
     return c10::cuda::getStreamFromExternal(
@@ -151,7 +158,11 @@ void set_aten_stream_to_infinicore() {
             + std::to_string(error));
     }
 #elif defined(ENABLE_HYGON_API)
+#if INFINICORE_TORCH_VERSION_GE_2_11
+    c10::cuda::setCurrentCUDAStream(get_hip_stream());
+#else
     c10::hip::setCurrentHIPStream(get_hip_stream());
+#endif
 #elif defined(ENABLE_MOORE_API)
     c10::musa::setCurrentMUSAStream(get_musa_stream());
 #elif defined(ENABLE_CAMBRICON_API)

--- a/src/infinicore/ops/mha_kvcache/hygon/mha_kvcache_flashattn_hygon.cc
+++ b/src/infinicore/ops/mha_kvcache/hygon/mha_kvcache_flashattn_hygon.cc
@@ -40,7 +40,11 @@ void *plan(Tensor out,
 }
 
 void run(void *planned_meta) {
+#if INFINICORE_TORCH_VERSION_GE_2_11
+    c10::cuda::CUDAStreamGuard guard(infinicore::adaptor::get_hip_stream());
+#else
     c10::hip::HIPStreamGuard guard(infinicore::adaptor::get_hip_stream());
+#endif
     auto *p = reinterpret_cast<PlannedMeta *>(planned_meta);
 
     // Paged KV caches must be contiguous for flash-attn; avoid extra copies for q/metadata when already dense.

--- a/src/infinicore/ops/multi_head_attention/hygon/mha_flashattn_hygon.cc
+++ b/src/infinicore/ops/multi_head_attention/hygon/mha_flashattn_hygon.cc
@@ -36,7 +36,11 @@ void *plan(Tensor out,
 }
 
 void run(void *planned_meta) {
+#if INFINICORE_TORCH_VERSION_GE_2_11
+    c10::cuda::CUDAStreamGuard guard(infinicore::adaptor::get_hip_stream());
+#else
     c10::hip::HIPStreamGuard guard(infinicore::adaptor::get_hip_stream());
+#endif
     auto *p = reinterpret_cast<PlannedMeta *>(planned_meta);
 
     auto q = infinicore::adaptor::to_aten_tensor(p->q);

--- a/src/infinicore/ops/multi_head_attention_varlen/hygon/mha_varlen_flashattn_hygon.cc
+++ b/src/infinicore/ops/multi_head_attention_varlen/hygon/mha_varlen_flashattn_hygon.cc
@@ -56,7 +56,11 @@ void run(void *planned_meta) {
     (void)planned_meta;
     throw std::runtime_error("ATen is not enabled in this build");
 #else
+#if INFINICORE_TORCH_VERSION_GE_2_11
+    c10::cuda::CUDAStreamGuard guard(infinicore::adaptor::get_hip_stream());
+#else
     c10::hip::HIPStreamGuard guard(infinicore::adaptor::get_hip_stream());
+#endif
     auto *p = reinterpret_cast<PlannedMeta *>(planned_meta);
 
     auto q = infinicore::adaptor::to_aten_tensor(p->q);


### PR DESCRIPTION
问题：在bw1100上，torch版本是2.11，aten的命名空间不一样，导致编译报错。

解决方式： 新增了INFINICORE_TORCH_VERSION_GE_2_11宏， 表示 torch版本。该宏只会在bw1100的torch2.11时，起作用。 不影响以前的代码。


修改前：bw1000上正常，bw1100上编译报错。

修改后：bw1000和bw1100都正常，都可以做端到端graph的推理。

**bw1000**
<img width="1640" height="1076" alt="image" src="https://github.com/user-attachments/assets/9441be79-af65-479f-9cd9-240bb73b02a3" />

**bw1100**
<img width="815" height="416" alt="image" src="https://github.com/user-attachments/assets/7014111c-7b41-4bc8-841f-7f39057c713b" />
