### PR TITLE
perf(gemm): route all bf16 shapes through cublasLt on Kunlun, eliminting costly f32 fallback

### DIFF
--- a/src/infiniop/ops/gemm/kunlun/gemm_kunlun.cc
+++ b/src/infiniop/ops/gemm/kunlun/gemm_kunlun.cc
@@ -9,12 +9,17 @@ namespace op::gemm::kunlun {
 
 typedef device::kunlun::blas::Handle::Internal HandleInternal;
 
-static bool isLargeBf16SkinnyGemm(const MatmulInfo &info) {
-    return info.is_transed && info.n == 1 && info.m > 2048;
-}
-
 static bool useBf16Lt(const MatmulInfo &info) {
-    return !isLargeBf16SkinnyGemm(info);
+    // cublasLt (xblas) on Kunlun handles every bf16 shape correctly and fast,
+    // including the "large skinny" batch-1 decode GEMMs (is_transed, n == 1,
+    // m > 2048). Those used to be routed around cublasLt into an f32-cast
+    // fallback that re-cast the entire weight matrix (bf16 -> f32 -> gemm ->
+    // bf16, element-wise) on every token, which cost ~16-200ms per call for
+    // the projection/lm_head layers and made 0.6B-class inference ~80x slower
+    // than expected. The f32-cast path below remains only as a runtime
+    // fallback if cublasLt setup/matmul ever fails.
+    (void)info;
+    return true;
 }
 
 static size_t packedMatrixSize(size_t rows, size_t cols, size_t batch) {

--- a/src/infiniop/ops/random_sample/kunlun/kernel.h
+++ b/src/infiniop/ops/random_sample/kunlun/kernel.h
@@ -155,19 +155,20 @@ __device__ void findTopOneLocal(
 template <typename Tval, typename Tidx>
 __device__ void TopkKernel(__global_ptr__ Tval *values,
                            __global_ptr__ Tidx *indices,
-                           __global_ptr__ Tidx *indices_global, // 长度为cluster_num() * core_num() * topk
+                           __global_ptr__ Tidx *indices_global, // 长度为nclusters * core_num() * topk
                            __global_ptr__ Tval *values_global,  // 把长度为voc的values的前topk元素集中倒values_global
                            __local__ Tval *values_local,
                            __local__ Tidx *indices_local,
                            int voc,
                            int topk,
-                           int buf_size) {
+                           int buf_size,
+                           int nclusters) {
     int cid = core_id();
     if (cid >= core_num()) {
         return;
     }
     int thread_id = core_num() * cluster_id() + cid;
-    int nthreads = core_num() * cluster_num();
+    int nthreads = core_num() * nclusters;
 
     // 每个coreId分配step个元素
     int remain = voc % nthreads;
@@ -243,6 +244,10 @@ __device__ void TopkKernel(__global_ptr__ Tval *values,
                 LM2GM(indices_local, indices_global + thread_id * topk, topk * sizeof(Tidx));
             }
         }
+        // All threads must have finished writing values_global/indices_global and
+        // the DMA stores must have landed before thread 0 reduces them (same race
+        // as TopOneKernel: reading stale workspace gives a non-deterministic top-k).
+        sync_cluster();
         if (thread_id == 0) {
             findTopk(values_global, indices_global, nthreads * topk, topk);
         }
@@ -259,11 +264,11 @@ __device__ Tcompute softmaxSum(__global_ptr__ const Tval *probs,
                                __global_ptr__ Tcompute *sum_global) {
 
     int sm_size = (SM_SIZE / 2) / sizeof(Tval);
-    int all_sm_size = cluster_num() * sm_size;
+    int all_sm_size = CLUSTER_SIZE * sm_size;
     int sm_remain = voc % all_sm_size;
     int sm_repeat = (voc - sm_remain) / all_sm_size;
-    int sm_remain_cluster = sm_remain % cluster_num();
-    int sm_step_easy = (sm_remain - sm_remain_cluster) / cluster_num();
+    int sm_remain_cluster = sm_remain % CLUSTER_SIZE;
+    int sm_step_easy = (sm_remain - sm_remain_cluster) / CLUSTER_SIZE;
     int sm_step_hard = sm_step_easy + 1;
     int sm_step = (cluster_id() < sm_remain_cluster ? sm_step_hard : sm_step_easy);
     int sm_ind_start = (cluster_id() < sm_remain_cluster ? cluster_id() * sm_step_hard : sm_remain_cluster * sm_step_hard + (cluster_id() - sm_remain_cluster) * sm_step_easy);
@@ -314,11 +319,11 @@ __device__ Tcompute softmaxSum(__global_ptr__ const Tval *probs,
     __shared__ Tcompute all_sum;
     __shared__ Tcompute z_sm[CLUSTER_SIZE];
     if (core_id() == 0) {
-        GM2SM(sum_global_, z_sm, cluster_num() * sizeof(Tcompute));
+        GM2SM(sum_global_, z_sm, CLUSTER_SIZE * sizeof(Tcompute));
     }
     sync_cluster();
 
-    Tcompute all_sum_0 = op::common_kunlun::reduce_op::sum<BLOCK_SIZE, Tcompute, Tcompute>(z_sm, cluster_num());
+    Tcompute all_sum_0 = op::common_kunlun::reduce_op::sum<BLOCK_SIZE, Tcompute, Tcompute>(z_sm, CLUSTER_SIZE);
     if (core_id() == 0) {
         all_sum = all_sum_0;
     }
@@ -480,7 +485,8 @@ __global__ void randomSampleKernel(Tidx *result,
                                    Tval *values,
                                    Tidx *indices_global,
                                    Tval *values_global,
-                                   Tcompute *sum_global) {
+                                   Tcompute *sum_global,
+                                   int nclusters) {
 
     constexpr int buf_size = 128;
     __local__ Tval values_local[2 * buf_size];
@@ -493,7 +499,8 @@ __global__ void randomSampleKernel(Tidx *result,
                            indices_local,
                            voc,
                            topk,
-                           buf_size);
+                           buf_size,
+                           nclusters);
     sync_cluster();
     // 上面这部分是计算topk，数据分别存储在values_global,indices_global里面
 
@@ -522,13 +529,14 @@ __device__ void TopOneKernel(__global_ptr__ Tidx *result,
                              __local__ Tval *values_local,
                              __local__ Tidx *indices_local,
                              int voc,
-                             int buf_size) {
+                             int buf_size,
+                             int nclusters) {
     int cid = core_id();
     if (cid >= core_num()) {
         return;
     }
     int thread_id = core_num() * cluster_id() + cid;
-    int nthreads = core_num() * cluster_num();
+    int nthreads = core_num() * nclusters;
 
     // 每个coreId分配step个元素
     int remain = voc % nthreads;
@@ -572,8 +580,14 @@ __device__ void TopOneKernel(__global_ptr__ Tidx *result,
         LM2GM(values_local, values_global + thread_id, sizeof(Tval));
         LM2GM(indices_local, indices_global + thread_id, sizeof(Tidx));
     }
+    // All threads must have finished writing values_global/indices_global and
+    // the DMA stores must have landed before thread 0 reduces them. Without
+    // this barrier thread 0 races the other cores and may read stale workspace
+    // values, picking a wrong token non-deterministically (greedy decode).
+    sync_cluster();
     if (thread_id == 0) {
         findTopOne(values_global, indices_global, nthreads);
+        mfence(); // ensure the winner store lands before reading it back
         __local__ Tidx result_idx;
         GM2LM(indices_global, &result_idx, sizeof(Tidx));
         LM2GM(&result_idx, result, sizeof(Tidx));
@@ -584,7 +598,8 @@ __global__ void argmaxKernel(Tidx *result, const Tval *probs, int voc,
                              Tidx *indices,
                              Tval *values,
                              Tidx *indices_global,
-                             Tval *values_global) {
+                             Tval *values_global,
+                             int nclusters) {
     constexpr int buf_size = 128;
     __local__ Tval values_local[2 * buf_size];
     __local__ Tidx indices_local[2 * buf_size];
@@ -596,6 +611,7 @@ __global__ void argmaxKernel(Tidx *result, const Tval *probs, int voc,
                              values_local,
                              indices_local,
                              voc,
-                             buf_size);
+                             buf_size,
+                             nclusters);
 }
 #endif

--- a/src/infiniop/ops/random_sample/kunlun/random_sample_kunlun.xpu
+++ b/src/infiniop/ops/random_sample/kunlun/random_sample_kunlun.xpu
@@ -21,10 +21,8 @@ void launchKernel(void *workspace,
     int topk_ = topk <= (int)n ? topk : (int)n;
     bool dosample = topk_ > 1 && temperature != 0.0f && topp != 0.0f && random_val != 0.0f;
 
-    Tval *values = (Tval *)workspace_value;
-    xpu_memcpy(values, (Tval *)probs, n * sizeof(Tval), XPU_DEVICE_TO_DEVICE);
-    Tval *values_global = values + n;
-    char *workspace_sum = workspace_value + (n + cluster_num * core_num * topk_) * sizeof(Tval);
+    Tval *values_global = (Tval *)workspace_value;
+    char *workspace_sum = workspace_value + cluster_num * core_num * topk_ * sizeof(Tval);
     float *sum_global = (float *)workspace_sum;
     char *workspace_index = workspace_sum + cluster_num * sizeof(float);
     Tidx *indices = (Tidx *)workspace_index;
@@ -44,9 +42,10 @@ void launchKernel(void *workspace,
         argmaxKernel<Tval, Tidx>
             <<<cluster_num, core_num, stream>>>((Tidx *)result, (Tval *)probs, n,
                                                 indices,
-                                                values,
+                                                nullptr,
                                                 indices_global,
-                                                values_global);
+                                                values_global,
+                                                cluster_num);
     }
 }
 
@@ -79,7 +78,10 @@ infiniStatus_t Descriptor::create(
     int core_num = 64;
     int n = probs_desc->numel();
 
-    size_t workspace_size = (n + cluster_num * core_num * n) * (infiniSizeOf(probs_desc->dtype()) + infiniSizeOf(result_desc->dtype())) + cluster_num * sizeof(float);
+    size_t workspace_size = cluster_num * core_num * n * infiniSizeOf(probs_desc->dtype())
+                          + cluster_num * sizeof(float)
+                          + n * infiniSizeOf(result_desc->dtype())
+                          + cluster_num * core_num * n * infiniSizeOf(result_desc->dtype());
     *desc_ptr = new Descriptor(
         info,
         workspace_size,


### PR DESCRIPTION

  Eliminate the f32-cast fallback for large skinny bf16 GEMMs (batch-1
  decode with is_transed, n==1, m>2048).  cublasLt (xblas) handles every
  bf16 shape correctly; the previous f32 path re-cast the entire weight
  matrix on every token, costing 16–200 ms per projection/lm_head call
  and making 0.6B-class inference ~80× slower than expected.

  fix(random_sample): eliminate race conditions in top-k/top-1 kernels on Kunlun

  Add missing cluster-level barriers (`sync_cluster()` / `mfence()`) in
  `TopOneKernel` and `TopkKernel`.  Without them, thread 0 could read
  stale workspace values while other cores were still writing, causing
  non-deterministic wrong-token selection that manifested as garbled text
  during greedy decode and top-k sampling.



昆仑上优化前1054秒，优化后10秒以内

<img width="1859" height="716" alt="cc870cf9fd4f80629bff071c57f38c9f" src="https://github.com/user-attachments/assets/c40f4221-7bb9-4e52-9c3e-72c1d460ca73" />

优化后
<img width="1859" height="873" alt="69482e5ee499d10ef61d2e587aff6c0a" src="https://github.com/user-attachments/assets/43b42e60-7500-4667-a119-582b927e5be2" />


<img width="1477" height="527" alt="image" src="https://github.com/user-attachments/assets/0bc59ed3-9a1a-4841-b87c-856a15a98b57" />

<img width="1476" height="685" alt="image" src="https://github.com/user-attachments/assets/0d5c1700-f07e-4eb4-9d79-96bbdb09e0d6" />



test_perf测试

优化前性能：
<img width="1868" height="367" alt="image" src="https://github.com/user-attachments/assets/86857139-ab48-409c-a863-79158b9819c9" />
<img width="1022" height="387" alt="image" src="https://github.com/user-attachments/assets/ceb13790-413b-4230-b482-0b116b849f7d" />

优化后性能：
<img width="1479" height="950" alt="image" src="https://github.com/user-attachments/assets/43df92ae-889b-45bb-ad39-efe9b1841d86" />



后续应该仍然有优化空间，profiling看到有蛮多同步操作，后续优化再提PR吧
<img width="1038" height="570" alt="image" src="https://github.com/user-attachments/assets/9385aef8-fd2b-4a08-aecf-2f5e4193102f" />









